### PR TITLE
Add rss feed to right hand pane

### DIFF
--- a/output/index.html
+++ b/output/index.html
@@ -239,8 +239,9 @@
                 <h3>Links</h3>
                 <ul>
                     <li><a href="https://www.worksafebc.com/en">WorkSafeBC</a></li>
-                    <li><a href="https://www.worksafebc.com/en/about-us/news-events/campaigns/2019/September/connect-to-an-it-career-with-a-difference">WorkSafeBC IT is hiring</a></li>
                     <li><a href="https://www.worksafebc.com/en/about-us/careers">Careers</a></li>
+                    <li><a href="https://www.worksafebc.com/en/about-us/news-events/campaigns/2019/September/connect-to-an-it-career-with-a-difference">We are hiring</a></li>
+                    <li><a href="https://wsbctechnicalblog.github.io/feeds/posts.atom.xml">rss feed</a></li>
                 </ul>
             </div>
          </div>


### PR DESCRIPTION
@alexbunardzic  @wsbctechnicalblog - Suggest adding the rss feed to the right hand-side navigation and shorten "WorkSafeBC is hiring" to "We are hiring" to avoid wrapping. 

LOW PRIORITY suggestion. Feel free to nuke the PR.