### PR TITLE
Use rendered HTML links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 WorkSafeBC provides this technical blog to assist individuals and organizations who are looking for articles pertaining to software engineering. The blog is non-exhaustive. There may be other useful technical resources not found in the blog.
 
-See [Terms of Use](/pages/terms-of-use.html) for details on how this blog is licensed.
+See [Terms of Use](https://wsbctechnicalblog.github.io/pages/terms-of-use.html) for details on how this blog is licensed.
 
 ---
 
@@ -20,7 +20,7 @@ WorkSafeBC engineers and other interesting subject matter experts share their kn
 
 ![How To](/images/readme-3.png)
 
-See [Our quest to share our knowledge with the world, keeping it interesting and informal](/blog-post-101.html) for guidance on how to navigate and create content for our technical blog.
+See [Our quest to share our knowledge with the world, keeping it interesting and informal](https://wsbctechnicalblog.github.io/blog-post-101.html) for guidance on how to navigate and create content for our technical blog.
 
 ---
 
@@ -28,5 +28,5 @@ See [Our quest to share our knowledge with the world, keeping it interesting and
 
 ![Contact](/images/readme-4.png)
 
-If you need more information or have feedback, please contact Willy Schaub. You can find his contact details in the [authors](/pages/authors.html) page.
+If you need more information or have feedback, please contact Willy Schaub. You can find his contact details in the [authors](https://wsbctechnicalblog.github.io/pages/authors.html) page.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See [Terms of Use](https://wsbctechnicalblog.github.io/pages/terms-of-use.html) 
 
 ![Contributors](/images/readme-2.png)
 
-WorkSafeBC engineers and other interesting subject matter experts share their knowledge, learnings, experiences, and failures. You can find more details on some of the authors [here](/pages/authors.html).
+WorkSafeBC engineers and other interesting subject matter experts share their knowledge, learnings, experiences, and failures. You can find more details on some of the authors [here](https://wsbctechnicalblog.github.io/pages/authors.html).
 
 ---
 


### PR DESCRIPTION
Reference the rendered HTML pages in the REDME. Doubt that lawyers want to read the rough HTML files.