### PR TITLE
Update tag counts and post counts across multiple HTML files

### DIFF
--- a/accelerate-devops-with-github-book.html
+++ b/accelerate-devops-with-github-book.html
@@ -139,13 +139,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -172,7 +173,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -204,7 +204,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/ad-groups-for-ci-cd-pipelines.html
+++ b/ad-groups-for-ci-cd-pipelines.html
@@ -141,13 +141,14 @@ We realized that some of our email-enabled AD security groups received no notifi
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -174,7 +175,6 @@ We realized that some of our email-enabled AD security groups received no notifi
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -206,7 +206,7 @@ We realized that some of our email-enabled AD security groups received no notifi
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/agile-planning-choice.html
+++ b/agile-planning-choice.html
@@ -327,13 +327,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -360,7 +361,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -392,7 +392,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/ai-assisted-dev-taming-azdo-yaml-part-2.html
+++ b/ai-assisted-dev-taming-azdo-yaml-part-2.html
@@ -355,13 +355,14 @@ Thank you.
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -388,7 +389,6 @@ Thank you.
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -420,7 +420,7 @@ Thank you.
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/ai-assisted-dev-taming-azdo-yaml.html
+++ b/ai-assisted-dev-taming-azdo-yaml.html
@@ -206,13 +206,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -239,7 +240,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -271,7 +271,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/ai-fundamentals-ai900-ai-guiding-principles.html
+++ b/ai-fundamentals-ai900-ai-guiding-principles.html
@@ -147,13 +147,14 @@ These are my living <strong>personal</strong> study notes. Use them at your own 
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -180,7 +181,6 @@ These are my living <strong>personal</strong> study notes. Use them at your own 
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -212,7 +212,7 @@ These are my living <strong>personal</strong> study notes. Use them at your own 
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/ai-fundamentals-ai900-bots.html
+++ b/ai-fundamentals-ai900-bots.html
@@ -132,13 +132,14 @@ These are my living <strong>personal</strong> study notes. Use them at your own 
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -165,7 +166,6 @@ These are my living <strong>personal</strong> study notes. Use them at your own 
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -197,7 +197,7 @@ These are my living <strong>personal</strong> study notes. Use them at your own 
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/ai-fundamentals-ai900-common-machine-learning-types.html
+++ b/ai-fundamentals-ai900-common-machine-learning-types.html
@@ -194,13 +194,14 @@ These are my living <strong>personal</strong> study notes. Use them at your own 
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -227,7 +228,6 @@ These are my living <strong>personal</strong> study notes. Use them at your own 
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -259,7 +259,7 @@ These are my living <strong>personal</strong> study notes. Use them at your own 
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/ai-fundamentals-ai900-common-workloads.html
+++ b/ai-fundamentals-ai900-common-workloads.html
@@ -135,13 +135,14 @@ These are my living <strong>personal</strong> study notes. Use them at your own 
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -168,7 +169,6 @@ These are my living <strong>personal</strong> study notes. Use them at your own 
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -200,7 +200,7 @@ These are my living <strong>personal</strong> study notes. Use them at your own 
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/ai-fundamentals-ai900-generative-ai.html
+++ b/ai-fundamentals-ai900-generative-ai.html
@@ -133,13 +133,14 @@ These are my living <strong>personal</strong> study notes. Use them at your own 
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -166,7 +167,6 @@ These are my living <strong>personal</strong> study notes. Use them at your own 
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -198,7 +198,7 @@ These are my living <strong>personal</strong> study notes. Use them at your own 
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/ai-fundamentals-ai900-natural-language-processing.html
+++ b/ai-fundamentals-ai900-natural-language-processing.html
@@ -146,13 +146,14 @@ These are my living <strong>personal</strong> study notes. Use them at your own 
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -179,7 +180,6 @@ These are my living <strong>personal</strong> study notes. Use them at your own 
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -211,7 +211,7 @@ These are my living <strong>personal</strong> study notes. Use them at your own 
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/ai-fundamentals-ai900-poster.html
+++ b/ai-fundamentals-ai900-poster.html
@@ -114,13 +114,14 @@ These are my <strong>personal</strong> study notes. Use them at your own <strong
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -147,7 +148,6 @@ These are my <strong>personal</strong> study notes. Use them at your own <strong
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -179,7 +179,7 @@ These are my <strong>personal</strong> study notes. Use them at your own <strong
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/ai-fundamentals-ai900-vision-workloads.html
+++ b/ai-fundamentals-ai900-vision-workloads.html
@@ -137,13 +137,14 @@ These are my living <strong>personal</strong> study notes. Use them at your own 
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -170,7 +171,6 @@ These are my living <strong>personal</strong> study notes. Use them at your own 
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -202,7 +202,7 @@ These are my living <strong>personal</strong> study notes. Use them at your own 
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/ai-fundamentals-prompt-analysis.html
+++ b/ai-fundamentals-prompt-analysis.html
@@ -190,13 +190,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -223,7 +224,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -255,7 +255,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/ai-fundamentals-prompts-pre-dotnet-10-upgrade-analysis.html
+++ b/ai-fundamentals-prompts-pre-dotnet-10-upgrade-analysis.html
@@ -200,13 +200,14 @@ Do <em>not</em> apply the Upgrade Assistant pipeline.  </p>
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -233,7 +234,6 @@ Do <em>not</em> apply the Upgrade Assistant pipeline.  </p>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -265,7 +265,7 @@ Do <em>not</em> apply the Upgrade Assistant pipeline.  </p>
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/announcement-ci-cd-cookbook-kindle.html
+++ b/announcement-ci-cd-cookbook-kindle.html
@@ -114,13 +114,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -147,7 +148,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -179,7 +179,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/announcement-ci-cd-cookbook.html
+++ b/announcement-ci-cd-cookbook.html
@@ -131,13 +131,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -164,7 +165,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -196,7 +196,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/apathy-for-details.html
+++ b/apathy-for-details.html
@@ -135,13 +135,14 @@ To create the client before we create the code that will serve the client’s ex
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -168,7 +169,6 @@ To create the client before we create the code that will serve the client’s ex
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -200,7 +200,7 @@ To create the client before we create the code that will serve the client’s ex
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/archives.html
+++ b/archives.html
@@ -40,6 +40,8 @@
 <h1>Archives for </h1>
 
 <dl>
+    <dt>Wed 25 February 2026</dt>
+    <dd><a href="https://wsbctechnicalblog.github.io/engineering-practices-branch-rename.html">Renaming Git Branches in Azure DevOps: A Simple Task, Eight Easy Steps, and Mild Despair</a></dd>
     <dt>Tue 24 February 2026</dt>
     <dd><a href="https://wsbctechnicalblog.github.io/ai-fundamentals-prompts-pre-dotnet-10-upgrade-analysis.html">Mastering the Art of Prompting: Pre-.NET10 Upgrade Analysis</a></dd>
     <dt>Mon 16 February 2026</dt>
@@ -571,13 +573,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -604,7 +607,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -636,7 +638,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/area-paths-and-nodes.html
+++ b/area-paths-and-nodes.html
@@ -112,13 +112,14 @@ operator. Imagine you walk up to a project containing hundreds of area paths and
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -145,7 +146,6 @@ operator. Imagine you walk up to a project containing hundreds of area paths and
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -177,7 +177,7 @@ operator. Imagine you walk up to a project containing hundreds of area paths and
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/author/aditya-chourasiya.html
+++ b/author/aditya-chourasiya.html
@@ -94,13 +94,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -127,7 +128,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -159,7 +159,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/author/alex-bunardzic-christine-ozeroff.html
+++ b/author/alex-bunardzic-christine-ozeroff.html
@@ -82,13 +82,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -115,7 +116,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -147,7 +147,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/author/alex-bunardzic.html
+++ b/author/alex-bunardzic.html
@@ -634,13 +634,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -667,7 +668,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -699,7 +699,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/author/andre-kaminski.html
+++ b/author/andre-kaminski.html
@@ -94,13 +94,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -127,7 +128,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -159,7 +159,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/author/andreas-mertens.html
+++ b/author/andreas-mertens.html
@@ -82,13 +82,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -115,7 +116,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -147,7 +147,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/author/daniel-broderick.html
+++ b/author/daniel-broderick.html
@@ -82,13 +82,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -115,7 +116,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -147,7 +147,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/author/laurent-blain.html
+++ b/author/laurent-blain.html
@@ -82,13 +82,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -115,7 +116,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -147,7 +147,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/author/martin-lacey.html
+++ b/author/martin-lacey.html
@@ -142,13 +142,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -175,7 +176,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -207,7 +207,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/author/martin-m-lacey.html
+++ b/author/martin-m-lacey.html
@@ -202,13 +202,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -235,7 +236,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -267,7 +267,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/author/nicholas-januar.html
+++ b/author/nicholas-januar.html
@@ -94,13 +94,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -127,7 +128,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -159,7 +159,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/author/said-akram.html
+++ b/author/said-akram.html
@@ -82,13 +82,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -115,7 +116,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -147,7 +147,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/author/shay-vannery.html
+++ b/author/shay-vannery.html
@@ -106,13 +106,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -139,7 +140,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -171,7 +171,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/author/vikas-jawa.html
+++ b/author/vikas-jawa.html
@@ -82,13 +82,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -115,7 +116,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -147,7 +147,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/author/willy-peter-schaub.html
+++ b/author/willy-peter-schaub.html
@@ -46,6 +46,18 @@
 
             <!-- prima pagina -->
             <div class="main-article">
+                <div class="read-more">Wed 25 February 2026</div>
+ 
+                <h2><a href="https://wsbctechnicalblog.github.io/engineering-practices-branch-rename.html" rel=Bookmark title="Permalink to Renaming Git Branches in Azure DevOps: A Simple Task, Eight Easy Steps, and Mild Despair">Renaming Git Branches in Azure DevOps: A Simple Task, Eight Easy Steps, and Mild Despair</a></h2>
+                <p>
+                <p>How a One-Character Change Turned into a Full-Contact Git Exercise</p>            
+                </p>
+                   
+
+            </div>
+    
+            <!-- prima pagina -->
+            <div class="main-article">
                 <div class="read-more">Mon 16 February 2026</div>
  
                 <h2><a href="https://wsbctechnicalblog.github.io/zero-or-one-not-fault-lines-asking-the-right-ai-question.html" rel=Bookmark title="Permalink to Zero or One, not Fault Lines - Are we asking the right AI question?">Zero or One, not Fault Lines - Are we asking the right AI question?</a></h2>
@@ -2158,13 +2170,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -2191,7 +2204,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -2223,7 +2235,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/authors.html
+++ b/authors.html
@@ -52,7 +52,7 @@
         <li><a href="https://wsbctechnicalblog.github.io/author/said-akram.html">Said Akram</a> (1)</li>
         <li><a href="https://wsbctechnicalblog.github.io/author/shay-vannery.html">Shay Vannery</a> (3)</li>
         <li><a href="https://wsbctechnicalblog.github.io/author/vikas-jawa.html">Vikas Jawa</a> (1)</li>
-        <li><a href="https://wsbctechnicalblog.github.io/author/willy-peter-schaub.html">Willy-Peter Schaub</a> (174)</li>
+        <li><a href="https://wsbctechnicalblog.github.io/author/willy-peter-schaub.html">Willy-Peter Schaub</a> (175)</li>
     </ul>
             </div>
             <div class="large-2 aside column">
@@ -78,13 +78,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -111,7 +112,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -143,7 +143,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/automate-tests.html
+++ b/automate-tests.html
@@ -134,13 +134,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -167,7 +168,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -199,7 +199,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/automation-bad-day.html
+++ b/automation-bad-day.html
@@ -160,13 +160,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -193,7 +194,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -225,7 +225,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/automation-churn-and-angst.html
+++ b/automation-churn-and-angst.html
@@ -155,13 +155,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -188,7 +189,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -220,7 +220,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/automation-lesson-1.html
+++ b/automation-lesson-1.html
@@ -203,13 +203,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -236,7 +237,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -268,7 +268,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/automation-task-group-learning.html
+++ b/automation-task-group-learning.html
@@ -182,13 +182,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -215,7 +216,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -247,7 +247,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/automation-working-group.html
+++ b/automation-working-group.html
@@ -132,13 +132,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -165,7 +166,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -197,7 +197,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-boards-tips-ad-notifications.html
+++ b/azure-boards-tips-ad-notifications.html
@@ -122,13 +122,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -155,7 +156,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -187,7 +187,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-boards-tips-operations-team.html
+++ b/azure-boards-tips-operations-team.html
@@ -176,13 +176,14 @@ Dependencies are only shown for predecessor/successor links and dependency lines
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -209,7 +210,6 @@ Dependencies are only shown for predecessor/successor links and dependency lines
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -241,7 +241,7 @@ Dependencies are only shown for predecessor/successor links and dependency lines
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-boards-tips-retain-hierarchy-with-filter.html
+++ b/azure-boards-tips-retain-hierarchy-with-filter.html
@@ -127,13 +127,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -160,7 +161,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -192,7 +192,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-boards-tips-stop-messing-with-our-backlog.html
+++ b/azure-boards-tips-stop-messing-with-our-backlog.html
@@ -145,13 +145,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -178,7 +179,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -210,7 +210,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-boards-tips.html
+++ b/azure-boards-tips.html
@@ -180,13 +180,14 @@ Dependencies are only shown for predecessor/successor links and dependency lines
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -213,7 +214,6 @@ Dependencies are only shown for predecessor/successor links and dependency lines
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -245,7 +245,7 @@ Dependencies are only shown for predecessor/successor links and dependency lines
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-devops-agent-capabilities.html
+++ b/azure-devops-agent-capabilities.html
@@ -178,13 +178,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -211,7 +212,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -243,7 +243,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-devops-agile-planning-working-session.html
+++ b/azure-devops-agile-planning-working-session.html
@@ -181,13 +181,14 @@ Inspired by this approach, I decided to adopt a similar strategy for my working 
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -214,7 +215,6 @@ Inspired by this approach, I decided to adopt a similar strategy for my working 
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -246,7 +246,7 @@ Inspired by this approach, I decided to adopt a similar strategy for my working 
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-devops-dependencies.html
+++ b/azure-devops-dependencies.html
@@ -238,13 +238,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -271,7 +272,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -303,7 +303,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-devops-empty-closed-date-field-fix.html
+++ b/azure-devops-empty-closed-date-field-fix.html
@@ -328,13 +328,14 @@ Developed by Daniel Broderick
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -361,7 +362,6 @@ Developed by Daniel Broderick
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -393,7 +393,7 @@ Developed by Daniel Broderick
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-devops-empty-closed-date-field.html
+++ b/azure-devops-empty-closed-date-field.html
@@ -122,13 +122,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -155,7 +156,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -187,7 +187,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-devops-pipeline-oss-v2-1-flow.html
+++ b/azure-devops-pipeline-oss-v2-1-flow.html
@@ -140,13 +140,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -173,7 +174,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -205,7 +205,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-devops-simplicity-to-rule-them-all.html
+++ b/azure-devops-simplicity-to-rule-them-all.html
@@ -183,13 +183,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -216,7 +217,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -248,7 +248,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-devops-transient-faults.html
+++ b/azure-devops-transient-faults.html
@@ -178,13 +178,14 @@ HTTP Error 503. The service is unavailable.
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -211,7 +212,6 @@ HTTP Error 503. The service is unavailable.
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -243,7 +243,7 @@ HTTP Error 503. The service is unavailable.
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-pipeline-blueprints-explore-cd.html
+++ b/azure-pipeline-blueprints-explore-cd.html
@@ -427,13 +427,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -460,7 +461,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -492,7 +492,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-pipeline-blueprints-explore-info.html
+++ b/azure-pipeline-blueprints-explore-info.html
@@ -268,13 +268,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -301,7 +302,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -333,7 +333,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-pipeline-blueprints-explore-qa-scans.html
+++ b/azure-pipeline-blueprints-explore-qa-scans.html
@@ -293,13 +293,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -326,7 +327,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -358,7 +358,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-pipeline-blueprints-explore-start.html
+++ b/azure-pipeline-blueprints-explore-start.html
@@ -190,13 +190,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -223,7 +224,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -255,7 +255,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-pipeline-blueprints-explore-version.html
+++ b/azure-pipeline-blueprints-explore-version.html
@@ -274,13 +274,14 @@ GitVersion is a tool that generates a Semantic Version number based on your Git 
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -307,7 +308,6 @@ GitVersion is a tool that generates a Semantic Version number based on your Git 
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -339,7 +339,7 @@ GitVersion is a tool that generates a Semantic Version number based on your Git 
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-pipeline-blueprints-oss-sync-20240318.html
+++ b/azure-pipeline-blueprints-oss-sync-20240318.html
@@ -136,13 +136,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -169,7 +170,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -201,7 +201,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-pipeline-blueprints-oss-sync-20240322.html
+++ b/azure-pipeline-blueprints-oss-sync-20240322.html
@@ -120,13 +120,14 @@ Replace the conditionals using <code>text</code> stage names with <code>boolean<
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -153,7 +154,6 @@ Replace the conditionals using <code>text</code> stage names with <code>boolean<
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -185,7 +185,7 @@ Replace the conditionals using <code>text</code> stage names with <code>boolean<
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-pipeline-blueprints-oss-sync-20240405.html
+++ b/azure-pipeline-blueprints-oss-sync-20240405.html
@@ -121,13 +121,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -154,7 +155,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -186,7 +186,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-pipeline-blueprints-oss-sync-20240816.html
+++ b/azure-pipeline-blueprints-oss-sync-20240816.html
@@ -154,13 +154,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -187,7 +188,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -219,7 +219,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-pipeline-blueprints-oss-sync-20241019.html
+++ b/azure-pipeline-blueprints-oss-sync-20241019.html
@@ -155,13 +155,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -188,7 +189,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -220,7 +220,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-pipeline-blueprints-oss-sync-2025-01-05.html
+++ b/azure-pipeline-blueprints-oss-sync-2025-01-05.html
@@ -250,13 +250,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -283,7 +284,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -315,7 +315,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-pipeline-blueprints-oss-sync-2025-02-07.html
+++ b/azure-pipeline-blueprints-oss-sync-2025-02-07.html
@@ -198,13 +198,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -231,7 +232,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -263,7 +263,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-pipeline-blueprints-oss-sync-2025-05-13.html
+++ b/azure-pipeline-blueprints-oss-sync-2025-05-13.html
@@ -113,13 +113,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -146,7 +147,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -178,7 +178,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-pipeline-blueprints-oss-sync-2025-09-19.html
+++ b/azure-pipeline-blueprints-oss-sync-2025-09-19.html
@@ -207,13 +207,14 @@ One of our future aspirations is to standardize the <code>cd.yml</code> template
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -240,7 +241,6 @@ One of our future aspirations is to standardize the <code>cd.yml</code> template
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -272,7 +272,7 @@ One of our future aspirations is to standardize the <code>cd.yml</code> template
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-pipeline-blueprints-oss-sync-2025-12-23.html
+++ b/azure-pipeline-blueprints-oss-sync-2025-12-23.html
@@ -185,13 +185,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -218,7 +219,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -250,7 +250,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-pipeline-iac-flow-decision.html
+++ b/azure-pipeline-iac-flow-decision.html
@@ -173,13 +173,14 @@ The repositories and associated policies allows our engineers to recommend confi
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -206,7 +207,6 @@ The repositories and associated policies allows our engineers to recommend confi
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -238,7 +238,7 @@ The repositories and associated policies allows our engineers to recommend confi
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-pipeline-yaml-refactor-parameter-objects.html
+++ b/azure-pipeline-yaml-refactor-parameter-objects.html
@@ -335,13 +335,14 @@ WorkSafeBC Common Engineering</a> project. </p>
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -368,7 +369,6 @@ WorkSafeBC Common Engineering</a> project. </p>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -400,7 +400,7 @@ WorkSafeBC Common Engineering</a> project. </p>
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-pipelines-blueprint-qa-integration.html
+++ b/azure-pipelines-blueprint-qa-integration.html
@@ -172,13 +172,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -205,7 +206,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -237,7 +237,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-pipelines-conditional-logic.html
+++ b/azure-pipelines-conditional-logic.html
@@ -232,13 +232,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -265,7 +266,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -297,7 +297,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-pipelines-magic-v2-pipelines.html
+++ b/azure-pipelines-magic-v2-pipelines.html
@@ -177,13 +177,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -210,7 +211,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -242,7 +242,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-tfm-oss-sync-202400510.html
+++ b/azure-tfm-oss-sync-202400510.html
@@ -123,13 +123,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -156,7 +157,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -188,7 +188,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azure-tfm-oss-sync-20240322.html
+++ b/azure-tfm-oss-sync-20240322.html
@@ -122,13 +122,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -155,7 +156,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -187,7 +187,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/azuredevop-automation-stakeholders.html
+++ b/azuredevop-automation-stakeholders.html
@@ -329,13 +329,14 @@ requirements, you must find ways to:</p>
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -362,7 +363,6 @@ requirements, you must find ways to:</p>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -394,7 +394,7 @@ requirements, you must find ways to:</p>
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/back-to-basics-automation.html
+++ b/back-to-basics-automation.html
@@ -144,13 +144,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -177,7 +178,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -209,7 +209,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/back-to-basics-azdo-backlog-automation.html
+++ b/back-to-basics-azdo-backlog-automation.html
@@ -157,13 +157,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -190,7 +191,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -222,7 +222,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/back-to-basics-batch-size.html
+++ b/back-to-basics-batch-size.html
@@ -167,13 +167,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -200,7 +201,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -232,7 +232,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/back-to-basics-communication.html
+++ b/back-to-basics-communication.html
@@ -151,13 +151,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -184,7 +185,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -216,7 +216,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/back-to-basics-dealing-with-technical-debt.html
+++ b/back-to-basics-dealing-with-technical-debt.html
@@ -131,13 +131,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -164,7 +165,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -196,7 +196,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/back-to-basics-engineering.html
+++ b/back-to-basics-engineering.html
@@ -173,13 +173,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -206,7 +207,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -238,7 +238,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/back-to-basics-fear-of-change.html
+++ b/back-to-basics-fear-of-change.html
@@ -134,13 +134,14 @@ So, why is there such an Angst for AI?</p>
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -167,7 +168,6 @@ So, why is there such an Angst for AI?</p>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -199,7 +199,7 @@ So, why is there such an Angst for AI?</p>
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/back-to-basics-from-continuous-delivery-to-release-on-demand.html
+++ b/back-to-basics-from-continuous-delivery-to-release-on-demand.html
@@ -127,13 +127,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -160,7 +161,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -192,7 +192,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/back-to-basics-kanban.html
+++ b/back-to-basics-kanban.html
@@ -176,13 +176,14 @@ An actionable <strong>ACCEPTANCE CRITERIA</strong> is Key! Acceptance criteria s
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -209,7 +210,6 @@ An actionable <strong>ACCEPTANCE CRITERIA</strong> is Key! Acceptance criteria s
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -241,7 +241,7 @@ An actionable <strong>ACCEPTANCE CRITERIA</strong> is Key! Acceptance criteria s
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/back-to-basics-mental-health.html
+++ b/back-to-basics-mental-health.html
@@ -127,13 +127,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -160,7 +161,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -192,7 +192,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/back-to-basics-mmp-mvp-poc.html
+++ b/back-to-basics-mmp-mvp-poc.html
@@ -127,13 +127,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -160,7 +161,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -192,7 +192,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/back-to-basics-oss.html
+++ b/back-to-basics-oss.html
@@ -146,13 +146,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -179,7 +180,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -211,7 +211,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/back-to-basics-pr-validations.html
+++ b/back-to-basics-pr-validations.html
@@ -137,13 +137,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -170,7 +171,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -202,7 +202,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/back-to-basics-simplicity.html
+++ b/back-to-basics-simplicity.html
@@ -146,13 +146,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -179,7 +180,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -211,7 +211,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/back-to-basics-why-are-we-moving-to-v2-blueprints.html
+++ b/back-to-basics-why-are-we-moving-to-v2-blueprints.html
@@ -154,13 +154,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -187,7 +188,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -219,7 +219,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/back-to-basics-wip-limit.html
+++ b/back-to-basics-wip-limit.html
@@ -159,13 +159,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -192,7 +193,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -224,7 +224,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/bcit-computer-systems-technology-industry-sponsored-student-project.html
+++ b/bcit-computer-systems-technology-industry-sponsored-student-project.html
@@ -148,13 +148,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -181,7 +182,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -213,7 +213,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/be-positive.html
+++ b/be-positive.html
@@ -186,13 +186,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -219,7 +220,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -251,7 +251,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/benefits-of-boundaries.html
+++ b/benefits-of-boundaries.html
@@ -144,13 +144,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -177,7 +178,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -209,7 +209,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/benefits-of-frequent-deployments.html
+++ b/benefits-of-frequent-deployments.html
@@ -136,13 +136,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -169,7 +170,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -201,7 +201,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/blog-post-101.html
+++ b/blog-post-101.html
@@ -422,13 +422,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -455,7 +456,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -487,7 +487,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/branching-pull-request.html
+++ b/branching-pull-request.html
@@ -152,13 +152,14 @@ I am NOT saying that is the best strategy but based on experimentation it fits o
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -185,7 +186,6 @@ I am NOT saying that is the best strategy but based on experimentation it fits o
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -217,7 +217,7 @@ I am NOT saying that is the best strategy but based on experimentation it fits o
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/branching-trunk-based.html
+++ b/branching-trunk-based.html
@@ -150,13 +150,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -183,7 +184,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -215,7 +215,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/built-in-quality.html
+++ b/built-in-quality.html
@@ -135,13 +135,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -168,7 +169,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -200,7 +200,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/can-government-agencies-be-innovative.html
+++ b/can-government-agencies-be-innovative.html
@@ -134,13 +134,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -167,7 +168,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -199,7 +199,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/categories.html
+++ b/categories.html
@@ -40,7 +40,7 @@
     <h1>Categories for </h1>
     <ul class="tag-list">        <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
         <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-        <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+        <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
     </ul>
             </div>
             <div class="large-2 aside column">

--- a/category/events.html
+++ b/category/events.html
@@ -159,13 +159,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -192,7 +193,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -224,7 +224,7 @@
                 <ul>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/category/misc.html
+++ b/category/misc.html
@@ -87,13 +87,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -120,7 +121,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -152,7 +152,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/category/posts.html
+++ b/category/posts.html
@@ -44,6 +44,15 @@
 
 <blocks cols="2">
         <div class="sec-article">
+            <div class="read-more">Wed 25 February 2026</div>
+
+            <h3><a href="https://wsbctechnicalblog.github.io/engineering-practices-branch-rename.html" rel=Bookmark title="Permalink to Renaming Git Branches in Azure DevOps: A Simple Task, Eight Easy Steps, and Mild Despair">Renaming Git Branches in Azure DevOps: A Simple Task, Eight Easy Steps, and Mild Despair</a></h3>
+            <p>
+            <p>How a One-Character Change Turned into a Full-Contact Git Exercise</p>            
+            </p>
+        </div>
+
+        <div class="sec-article">
             <div class="read-more">Tue 24 February 2026</div>
 
             <h3><a href="https://wsbctechnicalblog.github.io/ai-fundamentals-prompts-pre-dotnet-10-upgrade-analysis.html" rel=Bookmark title="Permalink to Mastering the Art of Prompting: Pre-.NET10 Upgrade Analysis">Mastering the Art of Prompting: Pre-.NET10 Upgrade Analysis</a></h3>
@@ -2238,13 +2247,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -2271,7 +2281,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -2303,7 +2312,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/ceremony-center-of-enablement.html
+++ b/ceremony-center-of-enablement.html
@@ -190,13 +190,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -223,7 +224,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -255,7 +255,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/ceremony-community-of-practice.html
+++ b/ceremony-community-of-practice.html
@@ -201,13 +201,14 @@ If any of these metrics start dipping it is time to ask whether is is time to te
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -234,7 +235,6 @@ If any of these metrics start dipping it is time to ask whether is is time to te
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -266,7 +266,7 @@ If any of these metrics start dipping it is time to ask whether is is time to te
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/ceremony-focus-single-source.html
+++ b/ceremony-focus-single-source.html
@@ -148,13 +148,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -181,7 +182,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -213,7 +213,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/ceremony-learnings.html
+++ b/ceremony-learnings.html
@@ -184,13 +184,14 @@ A guardrail is likened to the safety barriers on a bridge, serving as a metaphor
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -217,7 +218,6 @@ A guardrail is likened to the safety barriers on a bridge, serving as a metaphor
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -249,7 +249,7 @@ A guardrail is likened to the safety barriers on a bridge, serving as a metaphor
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/ceremony-overview.html
+++ b/ceremony-overview.html
@@ -217,13 +217,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -250,7 +251,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -282,7 +282,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/ceremony-working-group.html
+++ b/ceremony-working-group.html
@@ -177,13 +177,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -210,7 +211,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -242,7 +242,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/cheat-sheet-to-migrate-generic-v1-templates-to-v2.html
+++ b/cheat-sheet-to-migrate-generic-v1-templates-to-v2.html
@@ -144,13 +144,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -177,7 +178,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -209,7 +209,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/checkout-at-the-right-time.html
+++ b/checkout-at-the-right-time.html
@@ -132,13 +132,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -165,7 +166,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -197,7 +197,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/client-expressiveness-and-security.html
+++ b/client-expressiveness-and-security.html
@@ -148,13 +148,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -181,7 +182,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -213,7 +213,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/code-as-text.html
+++ b/code-as-text.html
@@ -131,13 +131,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -164,7 +165,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -196,7 +196,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/collective-code-ownership.html
+++ b/collective-code-ownership.html
@@ -138,13 +138,14 @@ In a healthy team, when something goes wrong it is never “I thought SHE was go
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -171,7 +172,6 @@ In a healthy team, when something goes wrong it is never “I thought SHE was go
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -203,7 +203,7 @@ In a healthy team, when something goes wrong it is never “I thought SHE was go
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/common-engineering-journal-1.html
+++ b/common-engineering-journal-1.html
@@ -144,13 +144,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -177,7 +178,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -209,7 +209,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/common-engineering-journal-2.html
+++ b/common-engineering-journal-2.html
@@ -176,13 +176,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -209,7 +210,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -241,7 +241,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/common-engineering-journal-3.html
+++ b/common-engineering-journal-3.html
@@ -195,13 +195,14 @@ Our working agreement has triggered a range of other working agreements, such as
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -228,7 +229,6 @@ Our working agreement has triggered a range of other working agreements, such as
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -260,7 +260,7 @@ Our working agreement has triggered a range of other working agreements, such as
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/common-engineering-journal-4.html
+++ b/common-engineering-journal-4.html
@@ -174,13 +174,14 @@ without a balance, we cannot continuously deliver value!</p>
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -207,7 +208,6 @@ without a balance, we cannot continuously deliver value!</p>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -239,7 +239,7 @@ without a balance, we cannot continuously deliver value!</p>
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/common-engineering-journal-5.html
+++ b/common-engineering-journal-5.html
@@ -170,13 +170,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -203,7 +204,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -235,7 +235,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/common-engineering-journal-6.html
+++ b/common-engineering-journal-6.html
@@ -152,13 +152,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -185,7 +186,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -217,7 +217,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/common-engineering-journal-7.html
+++ b/common-engineering-journal-7.html
@@ -158,13 +158,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -191,7 +192,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -223,7 +223,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/common-engineering-journal-8.html
+++ b/common-engineering-journal-8.html
@@ -139,13 +139,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -172,7 +173,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -204,7 +204,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/common-engineering-journal-9.html
+++ b/common-engineering-journal-9.html
@@ -188,13 +188,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -221,7 +222,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -253,7 +253,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/communication-guidance-sideways.html
+++ b/communication-guidance-sideways.html
@@ -168,13 +168,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -201,7 +202,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -233,7 +233,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/communication-guidance-upwards.html
+++ b/communication-guidance-upwards.html
@@ -152,13 +152,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -185,7 +186,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -217,7 +217,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/configuration-and-or-dependency-management.html
+++ b/configuration-and-or-dependency-management.html
@@ -139,13 +139,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -172,7 +173,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -204,7 +204,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/consistency-standardization.html
+++ b/consistency-standardization.html
@@ -158,13 +158,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -191,7 +192,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -223,7 +223,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/context-switching-no-more.html
+++ b/context-switching-no-more.html
@@ -164,13 +164,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -197,7 +198,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -229,7 +229,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/continuous-delivery-in-the-enterprise.html
+++ b/continuous-delivery-in-the-enterprise.html
@@ -135,13 +135,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -168,7 +169,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -200,7 +200,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/coop-github-copilot-instructions.html
+++ b/coop-github-copilot-instructions.html
@@ -165,13 +165,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -198,7 +199,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -230,7 +230,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/coop-nicholas-common-engineering.html
+++ b/coop-nicholas-common-engineering.html
@@ -124,13 +124,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -157,7 +158,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -189,7 +189,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/cultivate-rapid-spreading-of-knowledge.html
+++ b/cultivate-rapid-spreading-of-knowledge.html
@@ -135,13 +135,14 @@ Reaching the state of the Flow is an expensive endeavor.</p>
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -168,7 +169,6 @@ Reaching the state of the Flow is an expensive endeavor.</p>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -200,7 +200,7 @@ Reaching the state of the Flow is an expensive endeavor.</p>
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/deterministic-tests.html
+++ b/deterministic-tests.html
@@ -137,13 +137,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -170,7 +171,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -202,7 +202,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/devOps-vancouver-meetup-engineering-empowerment-session-preparations.html
+++ b/devOps-vancouver-meetup-engineering-empowerment-session-preparations.html
@@ -149,13 +149,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -182,7 +183,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -214,7 +214,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/devops-analytics-strategy.html
+++ b/devops-analytics-strategy.html
@@ -176,13 +176,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -209,7 +210,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -241,7 +241,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/devops-value-proposition.html
+++ b/devops-value-proposition.html
@@ -119,13 +119,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -152,7 +153,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -184,7 +184,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/devops-vancouver-meetup-learnings.html
+++ b/devops-vancouver-meetup-learnings.html
@@ -171,13 +171,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -204,7 +205,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -236,7 +236,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/dojo-events.html
+++ b/dojo-events.html
@@ -150,13 +150,14 @@ Similarly, it may so happen that during one of the Community of Practice session
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -183,7 +184,6 @@ Similarly, it may so happen that during one of the Community of Practice session
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -215,7 +215,7 @@ Similarly, it may so happen that during one of the Community of Practice session
                 <ul>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/dojo-tdd-getting-started-demo.html
+++ b/dojo-tdd-getting-started-demo.html
@@ -117,13 +117,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -150,7 +151,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -182,7 +182,7 @@
                 <ul>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/dont-become-expert-beginner.html
+++ b/dont-become-expert-beginner.html
@@ -132,13 +132,14 @@ If Advanced Beginners graduate to the Expert Beginner level, they typically assu
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -165,7 +166,6 @@ If Advanced Beginners graduate to the Expert Beginner level, they typically assu
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -197,7 +197,7 @@ If Advanced Beginners graduate to the Expert Beginner level, they typically assu
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/dont-debug.html
+++ b/dont-debug.html
@@ -133,13 +133,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -166,7 +167,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -198,7 +198,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/dont-let-your-code-talk-to-strangers.html
+++ b/dont-let-your-code-talk-to-strangers.html
@@ -127,13 +127,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -160,7 +161,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -192,7 +192,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/dream-team-working-agreement-poster.html
+++ b/dream-team-working-agreement-poster.html
@@ -126,13 +126,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -159,7 +160,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -191,7 +191,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/embedding-a-quality-driven-engineering-mindset-in-our-dna.html
+++ b/embedding-a-quality-driven-engineering-mindset-in-our-dna.html
@@ -163,13 +163,14 @@ Scalability: Guardrails facilitate scaling efforts by ensuring that new code and
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -196,7 +197,6 @@ Scalability: Guardrails facilitate scaling efforts by ensuring that new code and
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -228,7 +228,7 @@ Scalability: Guardrails facilitate scaling efforts by ensuring that new code and
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/engineering-practice-engineering-interviews.html
+++ b/engineering-practice-engineering-interviews.html
@@ -151,13 +151,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -184,7 +185,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -216,7 +216,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/engineering-practice-feature-flags.html
+++ b/engineering-practice-feature-flags.html
@@ -206,13 +206,14 @@ Finally, effective story slicing ensures that teams can continuously integrate w
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -239,7 +240,6 @@ Finally, effective story slicing ensures that teams can continuously integrate w
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -271,7 +271,7 @@ Finally, effective story slicing ensures that teams can continuously integrate w
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/engineering-practice-layering.html
+++ b/engineering-practice-layering.html
@@ -170,13 +170,14 @@ can have unexpected side-effects.  This is <em>Boundary Bleed</em>, and it shoul
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -203,7 +204,6 @@ can have unexpected side-effects.  This is <em>Boundary Bleed</em>, and it shoul
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -235,7 +235,7 @@ can have unexpected side-effects.  This is <em>Boundary Bleed</em>, and it shoul
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/engineering-practice-naming-conventions.html
+++ b/engineering-practice-naming-conventions.html
@@ -166,13 +166,14 @@ across all development teams.</p>
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -199,7 +200,6 @@ across all development teams.</p>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -231,7 +231,7 @@ across all development teams.</p>
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/engineering-practice-nuggets.html
+++ b/engineering-practice-nuggets.html
@@ -127,13 +127,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -160,7 +161,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -192,7 +192,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/engineering-practice-part-of-the-solution.html
+++ b/engineering-practice-part-of-the-solution.html
@@ -123,13 +123,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -156,7 +157,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -188,7 +188,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/engineering-practice-practices-processes.html
+++ b/engineering-practice-practices-processes.html
@@ -124,13 +124,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -157,7 +158,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -189,7 +189,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/engineering-practices-branch-rename.html
+++ b/engineering-practices-branch-rename.html
@@ -8,7 +8,7 @@
         <script type="text/javascript" src="https://wsbctechnicalblog.github.io/theme/js/modernizr.js"></script>
         <link href='https://fonts.googleapis.com/css?family=Exo+2:400,300,700,300italic,400italic,700italic,900,900italic' rel='stylesheet' type='text/css'>
         <link rel="stylesheet" href="https://wsbctechnicalblog.github.io/theme/css/lamboz.css" media="all">
-        <title>The WHY, HOW, and WHAT of our technical blog - </title>
+        <title>Renaming Git Branches in Azure DevOps: A Simple Task, Eight Easy Steps, and Mild Despair - </title>
         <meta charset="utf-8" />
         
 </head>
@@ -33,57 +33,128 @@
         <div class="data-holder">
         <div class="row">
            <div class="large-10 content-column column">
-    <h1 style="font-size:2em;"><a href="https://wsbctechnicalblog.github.io/demo-technical-blog-1.html" rel="bookmark"
-            title="Permalink to The WHY, HOW, and WHAT of our technical blog">The WHY, HOW, and WHAT of our technical blog</a></h1>
+    <h1 style="font-size:2em;"><a href="https://wsbctechnicalblog.github.io/engineering-practices-branch-rename.html" rel="bookmark"
+            title="Permalink to Renaming Git Branches in Azure DevOps: A Simple Task, Eight Easy Steps, and Mild Despair">Renaming Git Branches in Azure DevOps: A Simple Task, Eight Easy Steps, and Mild Despair</a></h1>
 
 <img src="/theme/img/Logo-blogsize.png"><br />
 <div class="content-article">
     <header class="header-article">
-        <div class="read-more">Posted by Willy-Peter Schaub on Wed 22 June 2022</div>
+        <div class="read-more">Posted by Willy-Peter Schaub on Wed 25 February 2026</div>
  
    </header>
     <section class='article'>
         
         <div class="entry-summary">
-            <p>Creating a demo pull request and post for our technical blog demo.</p>
+            <p>How a One-Character Change Turned into a Full-Contact Git Exercise</p>
         </div>
     
         <div class="entry-content">
-            <p>I have been invited to share our insights into how we are experimenting and present our WorkSafeBC technical blog. To show how we moved from ideation to action, gather feedback, and connect with the audience I decided to create a pull request - which will be turned into an actual blog post by the time you read this. </p>
-<hr>
-<h1>WHY did we create this blog?</h1>
-<p>This blog is based on an initiative that started as an idea at our March 2021 InnoFest to explore how we can enter the open-source world, collaborate, and share our cutting-edge engineering practices, products, and innovation such as our application-type CI/CD pipeline blueprints, and show the rest of the world that WorkSafeBC is a phenomenal place for engineers to work for.</p>
-<p>We introduced the idea with the following slide (pulled from the original InnoFest 2-min pitch) ...</p>
-<p><img alt="WHY 1" src="../images/demo-technical-blog-1-1.png"></p>
-<p>... and suggested that users unfamiliar with WorkSafeBC often wonder if a <a href="/can-government-agencies-be-innovative.html">government agency can be innovative</a>. Our innovation may as well have been hiding in a black hole - the community ( YOU ) had no insight into the exciting stuff we were dabbling with.</p>
-<p><img alt="WHY 2" src="../images/demo-technical-blog-1-2.png"></p>
-<p>For example, we have shared all our insights and learnings of Azure Pipelines in the detailed <a href="https://wsbctechnicalblog.github.io/tag/pipelines.html">tag:pipelines</a> posts.</p>
-<hr>
-<h1>HOW did we create this blog?</h1>
-<p><img alt="How we did it" src="../images/demo-technical-blog-1-3.png"></p>
-<p>We opted to host the project on GitHub as an open-source project using open-source tools, such as <a href="https://get.foundation/">Bricks based on Zurb Foundation</a> and the <a href="https://bricks.stackexchange.com/users/311/sam-hocevar">Bricks by Sam Hocevar</a> and </p>
-<p>The blog is based on informal-style technical content, using engineering-friendly markup language, and relying on the pull request workflow for collaboration, review, and revisions.</p>
-<ul>
-<li>Each pull request is reviewed by at least two reviewers, typically a subject matter expert and a manager. </li>
-<li>Once reviewed, the pull request is approved, which triggers the GitHub actions to publish to the live blog.</li>
-</ul>
-<p>The result is a collaboration channel that has demonstrated to the rest of the world that WorkSafeBC is an innovative and cool company to work for.  </p>
-<p>We have been mentioned in the <strong>Top Stories</strong> by the <a href="https://devblogs.microsoft.com/devops/">Microsoft DevOps</a> channel a few times and have been approached by engineers from around the world through our personal Twitter and LinkedIn channels.</p>
-<hr>
-<h1>WHAT is next?</h1>
-<p><img alt="Next steps" src="../images/demo-technical-blog-1-4.png"></p>
-<p>What the demo highlights is that what started as a simple idea, using simple tooling, requires more tender loving care and an investment to make it an attractive and successful platform. </p>
-<p>We must <strong>enable comments</strong> to encourage collaboration and capture feedback, and <strong>enable telemetry</strong> so that we can track overall traffic and analyze popular content.</p>
-<p>Lastly, a branding guidance and alignment tweak would not only improve your user experience but align our blog with the rest of our organization in terms of the look-and-feel.</p>
-<p>Hope you enjoyed the demo. Thank you for listening / reading.</p>
+            <p>Every so often, we decide to “clean things up”. In this particular episode of organisational optimism, the goal was innocent enough: rename all branches from</p>
+<p><code>Release/&lt;branch-name&gt;</code>
+to
+<code>release/&lt;branch-name&gt;</code></p>
+<p>Lowercase. Consistent. Civilised.
+What could possibly go wrong?</p>
+<blockquote>
+<p><img alt="&lt;SAMPLE PIC&gt;" src="../images/engineering-practices-branch-rename-1.png"></p>
+</blockquote>
+<h1>Challenge 1: Case Sensitivity, or “Git Knows Better Than You”</h1>
+<blockquote>
+<p>The first obstacle is that we often believe that <code>Release/1.0</code> and <code>release/1.0</code> are two entirely different branches. As far as your local file system is concerned, they may very well be the same thing, or not. 
+</p>
+</blockquote>
+<p>Git, in turn, is case-sensitive. This leads to confusion, errors, and a general sense that you have personally offended your version control system.</p>
+<p>Microsoft documents this behaviour clearly, including why Azure Repos enforces it and why case-only changes are problematic:
+<a href="https://learn.microsoft.com/en-us/azure/devops/repos/git/case-sensitivity?view=azure-devops">Git case sebsitivity</a>.</p>
+<p>The short version: Git is right, the file system is awkward, and you are caught in the middle.</p>
+<h1>Challenge 2: There Are No Branch Folders</h1>
+<blockquote>
+<p>Despite what the slash in <code>Release/1.0</code> suggests, Git does not have branch folders.
+There is no Release directory. There is no tree. There is no hierarchy.
+</p>
+</blockquote>
+<p>The <code>&lt;folder&gt;</code> portion of a branch name is merely a naming convention. It is a label. A polite fiction. A comforting illusion we all agree to maintain so that we can pretend our repositories are tidy.</p>
+<p>Internally, Git stores branches as references. The slash just happens to look like a folder, much like a cardboard box looks like furniture.</p>
+<h1>Challenge 3: There Is No Rename Feature</h1>
+<blockquote>
+<p>There is no <code>rename branch</code> button.
+</p>
+</blockquote>
+<p>Not in Git. Not in Azure DevOps. Not anywhere sensible.</p>
+<p>This is presumably because renaming a branch would be too easy, too humane, and would deprive future engineers of valuable character-building experiences.
+So instead, we simulate a rename by creating new branches and deleting old ones. Carefully. Repeatedly. With feeling.</p>
+<h1>The Only Way Forward</h1>
+<p>Because Git refuses to acknowledge that <code>Release</code> and <code>release</code> are “basically the same thing”, on Azure DevOps with case-sensitivity disabled, we need an intermediate step. A neutral ground. A diplomatic buffer.
+Let us call it <code>Temp</code>.</p>
+<h3>Step 1: Clone the Repository</h3>
+<div class="highlight"><pre><span></span><code>git clone https://dev.azure.com/your-org/your-project/_git/your-repocd your-repo
+</code></pre></div>
+
+<h3>Step 2: Rename Release/<em> to Temp/</em> Locally</h3>
+<p>Fetch all branches first:</p>
+<div class="highlight"><pre><span></span><code>git fetch --all
+</code></pre></div>
+
+<p>Rename the branch you are currently on:</p>
+<div class="highlight"><pre><span></span><code>git branch -m Release/1.0 Temp/1.0
+</code></pre></div>
+
+<p>Repeat this for all branches under <code>Release/*</code>:</p>
+<div class="highlight"><pre><span></span><code>git branch -m Release/1.1 Temp/1.1
+git branch -m Release/2.0 Temp/2.0
+...
+</code></pre></div>
+
+<h3>Step 3: Push the <code>Temp/*</code> Branches to Azure DevOps</h3>
+<div class="highlight"><pre><span></span><code>git push origin Temp/1.0git push origin Temp/1.1git push origin Temp/2.0Show more lines
+</code></pre></div>
+
+<h3>Step 4: Delete the Release/* Branches from Azure DevOps</h3>
+<div class="highlight"><pre><span></span><code>git push origin --delete Release/1.0
+git push origin --delete Release/2.0
+</code></pre></div>
+
+<p>At this point, the repository no longer contains Release/*. Everyone takes a deep breath.</p>
+<h3>Step 5: Re-clone the Repository</h3>
+<p>Yes, really. This avoids local case-confusion and reference residue.</p>
+<div class="highlight"><pre><span></span><code>cd ..
+rm -rf your-repo
+git clone https://dev.azure.com/your-org/your-project/_git/your-repo
+cd your-repo
+git fetch --all
+</code></pre></div>
+
+<h3>Step 6: Rename Temp/<em> to release/</em></h3>
+<div class="highlight"><pre><span></span><code>git branch -m Temp/1.0 release/1.0
+git branch -m Temp/2.0 release/2.0
+...
+</code></pre></div>
+
+<h3>Step 7: Push the <code>release/*</code> Branches to Azure DevOps</h3>
+<div class="highlight"><pre><span></span><code>git push origin release/1.0
+git push origin release/2.0
+...
+</code></pre></div>
+
+<h3>Step 8: Delete the Temp/* Branches from Azure DevOps</h3>
+<div class="highlight"><pre><span></span><code>git push origin --delete Temp/1.0
+git push origin --delete Temp/2.0
+...
+</code></pre></div>
+
+<h1>Final Thoughts</h1>
+<p>What began as a simple case change turned into a multi-stage choreography involving temporary branches, multiple pushes, deletions, and a ceremonial re-clone.</p>
+<p>Git is powerful. Azure DevOps is correct. The process is logical.</p>
+<p>It is also impressively unintuitive.</p>
+<p>I sincerely hope that someone out there has a better idea.</p>
         </div>
 
     </section>
     <footer class="footer-article">
-        <div class="tags-and-categories">Filed under <a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a>
-        | Tagged: <a href="https://wsbctechnicalblog.github.io/tag/event.html">event </a><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning </a>
-        | <a href="https://wsbctechnicalblog.github.io/demo-technical-blog-1.html" rel="bookmark"
-         title="Permalink to The WHY, HOW, and WHAT of our technical blog">Permalink</a>            
+        <div class="tags-and-categories">Filed under <a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a>
+        | Tagged: <a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering </a><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops </a><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control </a>
+        | <a href="https://wsbctechnicalblog.github.io/engineering-practices-branch-rename.html" rel="bookmark"
+         title="Permalink to Renaming Git Branches in Azure DevOps: A Simple Task, Eight Easy Steps, and Mild Despair">Permalink</a>            
         </div>
         <!-- metaldata 
         -->
@@ -193,9 +264,9 @@
             <div class="large-3 category-column column">
                 <h3>Categories</h3>
                 <ul>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/engineering-practices-dependency-injection.html
+++ b/engineering-practices-dependency-injection.html
@@ -130,13 +130,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -163,7 +164,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -195,7 +195,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/engineering-practices-fishbowl-dev-cop.html
+++ b/engineering-practices-fishbowl-dev-cop.html
@@ -122,13 +122,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -155,7 +156,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -187,7 +187,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/engineering-practices-legacy-and-eol-solutions.html
+++ b/engineering-practices-legacy-and-eol-solutions.html
@@ -150,13 +150,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -183,7 +184,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -215,7 +215,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/engineering-practices-metrics.html
+++ b/engineering-practices-metrics.html
@@ -142,13 +142,14 @@ At WorkSafe BC, I am thrilled to see Metrics as a key factor in everything, ever
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -175,7 +176,6 @@ At WorkSafe BC, I am thrilled to see Metrics as a key factor in everything, ever
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -207,7 +207,7 @@ At WorkSafe BC, I am thrilled to see Metrics as a key factor in everything, ever
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/engineering-practices-pull-request-v2.html
+++ b/engineering-practices-pull-request-v2.html
@@ -141,13 +141,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -174,7 +175,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -206,7 +206,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/engineering-practices-sdlc-improvements.html
+++ b/engineering-practices-sdlc-improvements.html
@@ -164,13 +164,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -197,7 +198,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -229,7 +229,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/engineering-practices-warnings-information-messages.html
+++ b/engineering-practices-warnings-information-messages.html
@@ -113,13 +113,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -146,7 +147,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -178,7 +178,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/engineering-practices-why-bugs-are-not-technical-debt.html
+++ b/engineering-practices-why-bugs-are-not-technical-debt.html
@@ -123,13 +123,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -156,7 +157,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -188,7 +188,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/engineering-practices-why-mutant-testing.html
+++ b/engineering-practices-why-mutant-testing.html
@@ -129,13 +129,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -162,7 +163,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -194,7 +194,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/experiment-yaml-1.html
+++ b/experiment-yaml-1.html
@@ -212,13 +212,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -245,7 +246,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -277,7 +277,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/fail-learn-reset-transform.html
+++ b/fail-learn-reset-transform.html
@@ -154,13 +154,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -187,7 +188,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -219,7 +219,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/fail-learn-reset.html
+++ b/fail-learn-reset.html
@@ -150,13 +150,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -183,7 +184,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -215,7 +215,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/feature-flag-driven-development.html
+++ b/feature-flag-driven-development.html
@@ -124,13 +124,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -157,7 +158,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -189,7 +189,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/feeds/all.atom.xml
+++ b/feeds/all.atom.xml
@@ -1,5 +1,102 @@
 <?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom"><title></title><link href="https://wsbctechnicalblog.github.io/" rel="alternate"></link><link href="https://wsbctechnicalblog.github.io/feeds/all.atom.xml" rel="self"></link><id>https://wsbctechnicalblog.github.io/</id><updated>2026-02-24T00:00:00-08:00</updated><entry><title>Mastering the Art of Prompting: Pre-.NET10 Upgrade Analysis</title><link href="https://wsbctechnicalblog.github.io/ai-fundamentals-prompts-pre-dotnet-10-upgrade-analysis.html" rel="alternate"></link><published>2026-02-24T00:00:00-08:00</published><updated>2026-02-24T00:00:00-08:00</updated><author><name>Andreas Mertens</name></author><id>tag:wsbctechnicalblog.github.io,2026-02-24:/ai-fundamentals-prompts-pre-dotnet-10-upgrade-analysis.html</id><summary type="html">&lt;p&gt;How We Use GitHub Copilot to Validate Application Health Ahead of a .NET Upgrade&lt;/p&gt;</summary><content type="html">&lt;p&gt;Upgrading a core technology stack is never just a technical exercise. It is a stakeholder experience challenge, a risk management exercise, and a cost avoidance opportunity. Before committing to a .NET upgrade, we need a clear, evidence‑based view of the health of our applications and the effort required to move forward with confidence.&lt;/p&gt;
+<feed xmlns="http://www.w3.org/2005/Atom"><title></title><link href="https://wsbctechnicalblog.github.io/" rel="alternate"></link><link href="https://wsbctechnicalblog.github.io/feeds/all.atom.xml" rel="self"></link><id>https://wsbctechnicalblog.github.io/</id><updated>2026-02-25T00:00:00-08:00</updated><entry><title>Renaming Git Branches in Azure DevOps: A Simple Task, Eight Easy Steps, and Mild Despair</title><link href="https://wsbctechnicalblog.github.io/engineering-practices-branch-rename.html" rel="alternate"></link><published>2026-02-25T00:00:00-08:00</published><updated>2026-02-25T00:00:00-08:00</updated><author><name>Willy-Peter Schaub</name></author><id>tag:wsbctechnicalblog.github.io,2026-02-25:/engineering-practices-branch-rename.html</id><summary type="html">&lt;p&gt;How a One-Character Change Turned into a Full-Contact Git Exercise&lt;/p&gt;</summary><content type="html">&lt;p&gt;Every so often, we decide to “clean things up”. In this particular episode of organisational optimism, the goal was innocent enough: rename all branches from&lt;/p&gt;
+&lt;p&gt;&lt;code&gt;Release/&amp;lt;branch-name&amp;gt;&lt;/code&gt;
+to
+&lt;code&gt;release/&amp;lt;branch-name&amp;gt;&lt;/code&gt;&lt;/p&gt;
+&lt;p&gt;Lowercase. Consistent. Civilised.
+What could possibly go wrong?&lt;/p&gt;
+&lt;blockquote&gt;
+&lt;p&gt;&lt;img alt="&amp;lt;SAMPLE PIC&amp;gt;" src="../images/engineering-practices-branch-rename-1.png"&gt;&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;h1&gt;Challenge 1: Case Sensitivity, or “Git Knows Better Than You”&lt;/h1&gt;
+&lt;blockquote&gt;
+&lt;p&gt;The first obstacle is that we often believe that &lt;code&gt;Release/1.0&lt;/code&gt; and &lt;code&gt;release/1.0&lt;/code&gt; are two entirely different branches. As far as your local file system is concerned, they may very well be the same thing, or not. 
+&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;p&gt;Git, in turn, is case-sensitive. This leads to confusion, errors, and a general sense that you have personally offended your version control system.&lt;/p&gt;
+&lt;p&gt;Microsoft documents this behaviour clearly, including why Azure Repos enforces it and why case-only changes are problematic:
+&lt;a href="https://learn.microsoft.com/en-us/azure/devops/repos/git/case-sensitivity?view=azure-devops"&gt;Git case sebsitivity&lt;/a&gt;.&lt;/p&gt;
+&lt;p&gt;The short version: Git is right, the file system is awkward, and you are caught in the middle.&lt;/p&gt;
+&lt;h1&gt;Challenge 2: There Are No Branch Folders&lt;/h1&gt;
+&lt;blockquote&gt;
+&lt;p&gt;Despite what the slash in &lt;code&gt;Release/1.0&lt;/code&gt; suggests, Git does not have branch folders.
+There is no Release directory. There is no tree. There is no hierarchy.
+&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;p&gt;The &lt;code&gt;&amp;lt;folder&amp;gt;&lt;/code&gt; portion of a branch name is merely a naming convention. It is a label. A polite fiction. A comforting illusion we all agree to maintain so that we can pretend our repositories are tidy.&lt;/p&gt;
+&lt;p&gt;Internally, Git stores branches as references. The slash just happens to look like a folder, much like a cardboard box looks like furniture.&lt;/p&gt;
+&lt;h1&gt;Challenge 3: There Is No Rename Feature&lt;/h1&gt;
+&lt;blockquote&gt;
+&lt;p&gt;There is no &lt;code&gt;rename branch&lt;/code&gt; button.
+&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;p&gt;Not in Git. Not in Azure DevOps. Not anywhere sensible.&lt;/p&gt;
+&lt;p&gt;This is presumably because renaming a branch would be too easy, too humane, and would deprive future engineers of valuable character-building experiences.
+So instead, we simulate a rename by creating new branches and deleting old ones. Carefully. Repeatedly. With feeling.&lt;/p&gt;
+&lt;h1&gt;The Only Way Forward&lt;/h1&gt;
+&lt;p&gt;Because Git refuses to acknowledge that &lt;code&gt;Release&lt;/code&gt; and &lt;code&gt;release&lt;/code&gt; are “basically the same thing”, on Azure DevOps with case-sensitivity disabled, we need an intermediate step. A neutral ground. A diplomatic buffer.
+Let us call it &lt;code&gt;Temp&lt;/code&gt;.&lt;/p&gt;
+&lt;h3&gt;Step 1: Clone the Repository&lt;/h3&gt;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;&lt;code&gt;git clone https://dev.azure.com/your-org/your-project/_git/your-repocd your-repo
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;h3&gt;Step 2: Rename Release/&lt;em&gt; to Temp/&lt;/em&gt; Locally&lt;/h3&gt;
+&lt;p&gt;Fetch all branches first:&lt;/p&gt;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;&lt;code&gt;git fetch --all
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;p&gt;Rename the branch you are currently on:&lt;/p&gt;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;&lt;code&gt;git branch -m Release/1.0 Temp/1.0
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;p&gt;Repeat this for all branches under &lt;code&gt;Release/*&lt;/code&gt;:&lt;/p&gt;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;&lt;code&gt;git branch -m Release/1.1 Temp/1.1
+git branch -m Release/2.0 Temp/2.0
+...
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;h3&gt;Step 3: Push the &lt;code&gt;Temp/*&lt;/code&gt; Branches to Azure DevOps&lt;/h3&gt;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;&lt;code&gt;git push origin Temp/1.0git push origin Temp/1.1git push origin Temp/2.0Show more lines
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;h3&gt;Step 4: Delete the Release/* Branches from Azure DevOps&lt;/h3&gt;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;&lt;code&gt;git push origin --delete Release/1.0
+git push origin --delete Release/2.0
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;p&gt;At this point, the repository no longer contains Release/*. Everyone takes a deep breath.&lt;/p&gt;
+&lt;h3&gt;Step 5: Re-clone the Repository&lt;/h3&gt;
+&lt;p&gt;Yes, really. This avoids local case-confusion and reference residue.&lt;/p&gt;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;&lt;code&gt;cd ..
+rm -rf your-repo
+git clone https://dev.azure.com/your-org/your-project/_git/your-repo
+cd your-repo
+git fetch --all
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;h3&gt;Step 6: Rename Temp/&lt;em&gt; to release/&lt;/em&gt;&lt;/h3&gt;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;&lt;code&gt;git branch -m Temp/1.0 release/1.0
+git branch -m Temp/2.0 release/2.0
+...
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;h3&gt;Step 7: Push the &lt;code&gt;release/*&lt;/code&gt; Branches to Azure DevOps&lt;/h3&gt;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;&lt;code&gt;git push origin release/1.0
+git push origin release/2.0
+...
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;h3&gt;Step 8: Delete the Temp/* Branches from Azure DevOps&lt;/h3&gt;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;&lt;code&gt;git push origin --delete Temp/1.0
+git push origin --delete Temp/2.0
+...
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;h1&gt;Final Thoughts&lt;/h1&gt;
+&lt;p&gt;What began as a simple case change turned into a multi-stage choreography involving temporary branches, multiple pushes, deletions, and a ceremonial re-clone.&lt;/p&gt;
+&lt;p&gt;Git is powerful. Azure DevOps is correct. The process is logical.&lt;/p&gt;
+&lt;p&gt;It is also impressively unintuitive.&lt;/p&gt;
+&lt;p&gt;I sincerely hope that someone out there has a better idea.&lt;/p&gt;</content><category term="Posts"></category><category term="engineering"></category><category term="azure-devops"></category><category term="version-control"></category></entry><entry><title>Mastering the Art of Prompting: Pre-.NET10 Upgrade Analysis</title><link href="https://wsbctechnicalblog.github.io/ai-fundamentals-prompts-pre-dotnet-10-upgrade-analysis.html" rel="alternate"></link><published>2026-02-24T00:00:00-08:00</published><updated>2026-02-24T00:00:00-08:00</updated><author><name>Andreas Mertens</name></author><id>tag:wsbctechnicalblog.github.io,2026-02-24:/ai-fundamentals-prompts-pre-dotnet-10-upgrade-analysis.html</id><summary type="html">&lt;p&gt;How We Use GitHub Copilot to Validate Application Health Ahead of a .NET Upgrade&lt;/p&gt;</summary><content type="html">&lt;p&gt;Upgrading a core technology stack is never just a technical exercise. It is a stakeholder experience challenge, a risk management exercise, and a cost avoidance opportunity. Before committing to a .NET upgrade, we need a clear, evidence‑based view of the health of our applications and the effort required to move forward with confidence.&lt;/p&gt;
 &lt;p&gt;In this post, I will offer a practical peek into how we analyse application health using GitHub Copilot as an assistive capability, not a shortcut. We focus on understanding code quality, dependency risk, architectural debt, and upgrade readiness across our portfolio. GitHub Copilot helps us accelerate discovery, highlight patterns, and surface potential issues earlier, allowing our teams to spend more time on judgement, decision‑making, and remediation.&lt;/p&gt;
 &lt;blockquote&gt;
 &lt;p&gt;&lt;img alt="Analysis Image" src="../images/ai-fundamentals-prompts-pre-dotnet-10-upgrade-analysis-1.png"&gt; &lt;/p&gt;
@@ -3613,96 +3710,6 @@ These are my living &lt;strong&gt;personal&lt;/strong&gt; study notes. Use them 
 &lt;p&gt;Enjoy other learning notes:&lt;/p&gt;
 &lt;ul&gt;
 &lt;li&gt;&lt;a href="/ai-fundamentals-ai900-common-machine-learning-types.html"&gt;common-machine-learning-types&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href="/ai-fundamentals-ai900-common-workloads.html"&gt;common-workloads&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href="/ai-fundamentals-ai900-generative-ai.html"&gt;generative-ai&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href="/ai-fundamentals-ai900-ai-guiding-principles.html"&gt;guiding-principles&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href="/ai-fundamentals-ai900-natural-language-processing.html"&gt;natural-language-processing&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href="/ai-fundamentals-ai900-vision-workloads.html"&gt;vision-workloads&lt;/a&gt;&lt;/li&gt;
-&lt;/ul&gt;
-&lt;p&gt;AI-900 Quick reference Poster:&lt;/p&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;a href="/ai-fundamentals-ai900-poster.html"&gt;ai-900 poster&lt;/a&gt;&lt;/li&gt;
-&lt;/ul&gt;</content><category term="Posts"></category><category term="ai"></category><category term="learning"></category></entry><entry><title>Artificial Intelligence - AI-900 - Common Machine Learning Types</title><link href="https://wsbctechnicalblog.github.io/ai-fundamentals-ai900-common-machine-learning-types.html" rel="alternate"></link><published>2024-09-27T00:00:00-07:00</published><updated>2024-09-27T00:00:00-07:00</updated><author><name>Willy-Peter Schaub</name></author><id>tag:wsbctechnicalblog.github.io,2024-09-27:/ai-fundamentals-ai900-common-machine-learning-types.html</id><summary type="html">&lt;p&gt;"AI machine learning (ML) refers to the subset of artificial intelligence focused on developing algorithms and models that enable computers to learn from data and improve their performance over time without being explicitly programmed." - ChatGPT GPT-4o&lt;/p&gt;</summary><content type="html">&lt;blockquote&gt;
-&lt;p&gt;&lt;img alt="alert" src="../images/alert-tiny.png"&gt;
-These are my living &lt;strong&gt;personal&lt;/strong&gt; study notes. Use them at your own &lt;strong&gt;risk&lt;/strong&gt;!
-&lt;/p&gt;
-&lt;p&gt;&lt;img alt="common-machine-learning-types" src="../images/ai-fundamentals-ai900-common-machine-learning-types.png"&gt; &lt;/p&gt;
-&lt;/blockquote&gt;
-&lt;h2&gt;Notes&lt;/h2&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;strong&gt;Classification&lt;/strong&gt; predicts categories of data, such as sentiment if users on the X platform.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Clustering algorithm&lt;/strong&gt; automatically finds the optimal way to split a data set into groups without training.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Feature engineering&lt;/strong&gt; is the method of creating new features, based on existing features.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Feature selection&lt;/strong&gt; allows us to narrow down the features that are important for &lt;strong&gt;label&lt;/strong&gt; predictions.&lt;/li&gt;
-&lt;li&gt;Training a &lt;strong&gt;Regression&lt;/strong&gt; model involves data gathering and transformation: &lt;strong&gt;Feature selection&lt;/strong&gt; --&amp;gt; &lt;strong&gt;Finding and Cleaning&lt;/strong&gt; outliers --&amp;gt; &lt;strong&gt;Impute&lt;/strong&gt; missing values --&amp;gt; &lt;strong&gt;Normalization&lt;/strong&gt; or &lt;strong&gt;Feature engineering&lt;/strong&gt;.&lt;/li&gt;
-&lt;/ul&gt;
-&lt;h2&gt;Metrics&lt;/h2&gt;
-&lt;blockquote&gt;
-&lt;p&gt;Confusion Matrix Terms
-&lt;/p&gt;
-&lt;/blockquote&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;strong&gt;True Positive (TP)&lt;/strong&gt; - number of positive cases predicted correctly.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;True Negative (TN)&lt;/strong&gt; - number of negative cases predicted correctly.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;False Positive (FP)&lt;/strong&gt; - number of positive cases predicted incorrectly - Type 1 error.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;False Negative (FN)&lt;/strong&gt; - number of negative cases predicted incorrectly - Type 2 error.&lt;/li&gt;
-&lt;/ul&gt;
-&lt;blockquote&gt;
-&lt;p&gt;Classification model
-&lt;/p&gt;
-&lt;/blockquote&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;strong&gt;Accuracy&lt;/strong&gt; - the ratio of predictions that exactly match the true class labels. Closer to 1 the better. Range: [0, 1]. Metric = (TP+TN)/(TP+FP+TN+FN).&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Area Under Curve (AUC)&lt;/strong&gt; reflects the model's performance - AUC=&lt;strong&gt;1&lt;/strong&gt; is best fitted model and AUC&amp;lt;&lt;strong&gt;0.5&lt;/strong&gt; is worse than random. Range: [0, 1].&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;AveragePrecision (AP)&lt;/strong&gt; is the combined metrics of both Precision and Recall, used in vision model.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Confusion matrix&lt;/strong&gt; provides a tabulated view of predicted abd actual values.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;F1 Score&lt;/strong&gt; - machine learning evaluation metric that combines precision and recall scores. Metric = (2&lt;em&gt;Precision&lt;/em&gt;Recall)/(Precision+Recall).&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Precision&lt;/strong&gt; - the ability of a model to avoid labeling negative samples as positive. Closer to 1 the better. Range: [0, 1]. Metric = TP/(TP+FP).&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Recall&lt;/strong&gt; - the ability of a model to detect all positive samples. Closer to 1 the better. Range: [0, 1]. TP/(TP+FN), where TP=true positive, FN=False negative.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Selectivity&lt;/strong&gt; - measures the ability of the model to correctly identify negative samples (i.e., true negatives) out of all the actual negative samples. Metric = TN/(TN+FP).&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Specificity&lt;/strong&gt; - the ability of a model to correctly identify negative instances. TN/(TN+FP)&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Weighted accuracy&lt;/strong&gt; is accuracy where each sample is weighted by the total number of samples belonging to the same class. Closer to 1 the better. Range: [0, 1].&lt;/li&gt;
-&lt;/ul&gt;
-&lt;blockquote&gt;
-&lt;p&gt;Regression Model
-&lt;/p&gt;
-&lt;/blockquote&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;strong&gt;Coefficient of determination&lt;/strong&gt;, often referred to as R2, represents the predictive power of the model. Closer to 1 the better. Range: [0, 1].&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Mean absolute error (MAE)&lt;/strong&gt; measures how close the predictions are to the actual outcomes. A lower score is better.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Root mean squared error (RMSE)&lt;/strong&gt; creates a single value that summarizes the error in the model. By squaring the difference, the metric disregards the difference between over-prediction and under-prediction.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Relative absolute error (RAE)&lt;/strong&gt; is the relative absolute difference between expected and actual values. The mean difference is divided by the arithmetic mean.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Relative squared error (RSE)&lt;/strong&gt; similarly normalizes the total squared error of the predicted values by dividing by the total squared error of the actual values.&lt;/li&gt;
-&lt;/ul&gt;
-&lt;blockquote&gt;
-&lt;p&gt;Clustering Model
-&lt;/p&gt;
-&lt;/blockquote&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;strong&gt;Average Distance to Other Center&lt;/strong&gt; represent how close, on average, each point in the cluster is to the centroids of all other clusters.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Average Distance to Cluster Center&lt;/strong&gt; represent the closeness of all points in a cluster to the centroid of that cluster.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Combined Evaluation&lt;/strong&gt; score at the bottom of each section of results lists the averaged scores for the clusters created in that particular model.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Maximal Distance to Cluster Center&lt;/strong&gt; represent the max of the distances between each point and the centroid of that point's cluster. High = dispersed.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Number of Points&lt;/strong&gt; shows how many data points were assigned to each cluster, along with the total overall number of data points in any cluster.&lt;/li&gt;
-&lt;/ul&gt;
-&lt;h2&gt;Example&lt;/h2&gt;
-&lt;blockquote&gt;
-&lt;p&gt;You need to examine historical data to forecast price ranges for your product. Label = prediction = price range.
-&lt;/p&gt;
-&lt;/blockquote&gt;
-&lt;ul&gt;
-&lt;li&gt;The &lt;strong&gt;classification&lt;/strong&gt; model is &lt;code&gt;suitable&lt;/code&gt; for supervised learning to determine &lt;code&gt;is it&lt;/code&gt; a low, medium, high, or very high price.&lt;/li&gt;
-&lt;li&gt;The &lt;strong&gt;regression&lt;/strong&gt; model is &lt;code&gt;inappropriate&lt;/code&gt; because it forecasts numerical values rather than determining whether something belongs to the "is it" class.&lt;/li&gt;
-&lt;li&gt;The &lt;strong&gt;clustering&lt;/strong&gt; model is &lt;code&gt;inappropriate&lt;/code&gt; because it clusters unlabeled data into similar groups.&lt;/li&gt;
-&lt;/ul&gt;
-&lt;hr&gt;
-&lt;p&gt;You perused:&lt;/p&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;strong&gt;this-&amp;gt;&lt;/strong&gt;&lt;a href="/ai-fundamentals-ai900-common-machine-learning-types.html"&gt;common-machine-learning-types&lt;/a&gt; &lt;/li&gt;
-&lt;/ul&gt;
-&lt;p&gt;Enjoy other learning notes:&lt;/p&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;a href="/ai-fundamentals-ai900-bots.html"&gt;bots&lt;/a&gt;&lt;/li&gt;
 &lt;li&gt;&lt;a href="/ai-fundamentals-ai900-common-workloads.html"&gt;common-workloads&lt;/a&gt;&lt;/li&gt;
 &lt;li&gt;&lt;a href="/ai-fundamentals-ai900-generative-ai.html"&gt;generative-ai&lt;/a&gt;&lt;/li&gt;
 &lt;li&gt;&lt;a href="/ai-fundamentals-ai900-ai-guiding-principles.html"&gt;guiding-principles&lt;/a&gt;&lt;/li&gt;

--- a/feeds/posts.atom.xml
+++ b/feeds/posts.atom.xml
@@ -1,5 +1,102 @@
 <?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom"><title>- Posts</title><link href="https://wsbctechnicalblog.github.io/" rel="alternate"></link><link href="https://wsbctechnicalblog.github.io/feeds/posts.atom.xml" rel="self"></link><id>https://wsbctechnicalblog.github.io/</id><updated>2026-02-24T00:00:00-08:00</updated><entry><title>Mastering the Art of Prompting: Pre-.NET10 Upgrade Analysis</title><link href="https://wsbctechnicalblog.github.io/ai-fundamentals-prompts-pre-dotnet-10-upgrade-analysis.html" rel="alternate"></link><published>2026-02-24T00:00:00-08:00</published><updated>2026-02-24T00:00:00-08:00</updated><author><name>Andreas Mertens</name></author><id>tag:wsbctechnicalblog.github.io,2026-02-24:/ai-fundamentals-prompts-pre-dotnet-10-upgrade-analysis.html</id><summary type="html">&lt;p&gt;How We Use GitHub Copilot to Validate Application Health Ahead of a .NET Upgrade&lt;/p&gt;</summary><content type="html">&lt;p&gt;Upgrading a core technology stack is never just a technical exercise. It is a stakeholder experience challenge, a risk management exercise, and a cost avoidance opportunity. Before committing to a .NET upgrade, we need a clear, evidence‑based view of the health of our applications and the effort required to move forward with confidence.&lt;/p&gt;
+<feed xmlns="http://www.w3.org/2005/Atom"><title>- Posts</title><link href="https://wsbctechnicalblog.github.io/" rel="alternate"></link><link href="https://wsbctechnicalblog.github.io/feeds/posts.atom.xml" rel="self"></link><id>https://wsbctechnicalblog.github.io/</id><updated>2026-02-25T00:00:00-08:00</updated><entry><title>Renaming Git Branches in Azure DevOps: A Simple Task, Eight Easy Steps, and Mild Despair</title><link href="https://wsbctechnicalblog.github.io/engineering-practices-branch-rename.html" rel="alternate"></link><published>2026-02-25T00:00:00-08:00</published><updated>2026-02-25T00:00:00-08:00</updated><author><name>Willy-Peter Schaub</name></author><id>tag:wsbctechnicalblog.github.io,2026-02-25:/engineering-practices-branch-rename.html</id><summary type="html">&lt;p&gt;How a One-Character Change Turned into a Full-Contact Git Exercise&lt;/p&gt;</summary><content type="html">&lt;p&gt;Every so often, we decide to “clean things up”. In this particular episode of organisational optimism, the goal was innocent enough: rename all branches from&lt;/p&gt;
+&lt;p&gt;&lt;code&gt;Release/&amp;lt;branch-name&amp;gt;&lt;/code&gt;
+to
+&lt;code&gt;release/&amp;lt;branch-name&amp;gt;&lt;/code&gt;&lt;/p&gt;
+&lt;p&gt;Lowercase. Consistent. Civilised.
+What could possibly go wrong?&lt;/p&gt;
+&lt;blockquote&gt;
+&lt;p&gt;&lt;img alt="&amp;lt;SAMPLE PIC&amp;gt;" src="../images/engineering-practices-branch-rename-1.png"&gt;&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;h1&gt;Challenge 1: Case Sensitivity, or “Git Knows Better Than You”&lt;/h1&gt;
+&lt;blockquote&gt;
+&lt;p&gt;The first obstacle is that we often believe that &lt;code&gt;Release/1.0&lt;/code&gt; and &lt;code&gt;release/1.0&lt;/code&gt; are two entirely different branches. As far as your local file system is concerned, they may very well be the same thing, or not. 
+&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;p&gt;Git, in turn, is case-sensitive. This leads to confusion, errors, and a general sense that you have personally offended your version control system.&lt;/p&gt;
+&lt;p&gt;Microsoft documents this behaviour clearly, including why Azure Repos enforces it and why case-only changes are problematic:
+&lt;a href="https://learn.microsoft.com/en-us/azure/devops/repos/git/case-sensitivity?view=azure-devops"&gt;Git case sebsitivity&lt;/a&gt;.&lt;/p&gt;
+&lt;p&gt;The short version: Git is right, the file system is awkward, and you are caught in the middle.&lt;/p&gt;
+&lt;h1&gt;Challenge 2: There Are No Branch Folders&lt;/h1&gt;
+&lt;blockquote&gt;
+&lt;p&gt;Despite what the slash in &lt;code&gt;Release/1.0&lt;/code&gt; suggests, Git does not have branch folders.
+There is no Release directory. There is no tree. There is no hierarchy.
+&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;p&gt;The &lt;code&gt;&amp;lt;folder&amp;gt;&lt;/code&gt; portion of a branch name is merely a naming convention. It is a label. A polite fiction. A comforting illusion we all agree to maintain so that we can pretend our repositories are tidy.&lt;/p&gt;
+&lt;p&gt;Internally, Git stores branches as references. The slash just happens to look like a folder, much like a cardboard box looks like furniture.&lt;/p&gt;
+&lt;h1&gt;Challenge 3: There Is No Rename Feature&lt;/h1&gt;
+&lt;blockquote&gt;
+&lt;p&gt;There is no &lt;code&gt;rename branch&lt;/code&gt; button.
+&lt;/p&gt;
+&lt;/blockquote&gt;
+&lt;p&gt;Not in Git. Not in Azure DevOps. Not anywhere sensible.&lt;/p&gt;
+&lt;p&gt;This is presumably because renaming a branch would be too easy, too humane, and would deprive future engineers of valuable character-building experiences.
+So instead, we simulate a rename by creating new branches and deleting old ones. Carefully. Repeatedly. With feeling.&lt;/p&gt;
+&lt;h1&gt;The Only Way Forward&lt;/h1&gt;
+&lt;p&gt;Because Git refuses to acknowledge that &lt;code&gt;Release&lt;/code&gt; and &lt;code&gt;release&lt;/code&gt; are “basically the same thing”, on Azure DevOps with case-sensitivity disabled, we need an intermediate step. A neutral ground. A diplomatic buffer.
+Let us call it &lt;code&gt;Temp&lt;/code&gt;.&lt;/p&gt;
+&lt;h3&gt;Step 1: Clone the Repository&lt;/h3&gt;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;&lt;code&gt;git clone https://dev.azure.com/your-org/your-project/_git/your-repocd your-repo
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;h3&gt;Step 2: Rename Release/&lt;em&gt; to Temp/&lt;/em&gt; Locally&lt;/h3&gt;
+&lt;p&gt;Fetch all branches first:&lt;/p&gt;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;&lt;code&gt;git fetch --all
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;p&gt;Rename the branch you are currently on:&lt;/p&gt;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;&lt;code&gt;git branch -m Release/1.0 Temp/1.0
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;p&gt;Repeat this for all branches under &lt;code&gt;Release/*&lt;/code&gt;:&lt;/p&gt;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;&lt;code&gt;git branch -m Release/1.1 Temp/1.1
+git branch -m Release/2.0 Temp/2.0
+...
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;h3&gt;Step 3: Push the &lt;code&gt;Temp/*&lt;/code&gt; Branches to Azure DevOps&lt;/h3&gt;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;&lt;code&gt;git push origin Temp/1.0git push origin Temp/1.1git push origin Temp/2.0Show more lines
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;h3&gt;Step 4: Delete the Release/* Branches from Azure DevOps&lt;/h3&gt;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;&lt;code&gt;git push origin --delete Release/1.0
+git push origin --delete Release/2.0
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;p&gt;At this point, the repository no longer contains Release/*. Everyone takes a deep breath.&lt;/p&gt;
+&lt;h3&gt;Step 5: Re-clone the Repository&lt;/h3&gt;
+&lt;p&gt;Yes, really. This avoids local case-confusion and reference residue.&lt;/p&gt;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;&lt;code&gt;cd ..
+rm -rf your-repo
+git clone https://dev.azure.com/your-org/your-project/_git/your-repo
+cd your-repo
+git fetch --all
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;h3&gt;Step 6: Rename Temp/&lt;em&gt; to release/&lt;/em&gt;&lt;/h3&gt;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;&lt;code&gt;git branch -m Temp/1.0 release/1.0
+git branch -m Temp/2.0 release/2.0
+...
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;h3&gt;Step 7: Push the &lt;code&gt;release/*&lt;/code&gt; Branches to Azure DevOps&lt;/h3&gt;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;&lt;code&gt;git push origin release/1.0
+git push origin release/2.0
+...
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;h3&gt;Step 8: Delete the Temp/* Branches from Azure DevOps&lt;/h3&gt;
+&lt;div class="highlight"&gt;&lt;pre&gt;&lt;span&gt;&lt;/span&gt;&lt;code&gt;git push origin --delete Temp/1.0
+git push origin --delete Temp/2.0
+...
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+
+&lt;h1&gt;Final Thoughts&lt;/h1&gt;
+&lt;p&gt;What began as a simple case change turned into a multi-stage choreography involving temporary branches, multiple pushes, deletions, and a ceremonial re-clone.&lt;/p&gt;
+&lt;p&gt;Git is powerful. Azure DevOps is correct. The process is logical.&lt;/p&gt;
+&lt;p&gt;It is also impressively unintuitive.&lt;/p&gt;
+&lt;p&gt;I sincerely hope that someone out there has a better idea.&lt;/p&gt;</content><category term="Posts"></category><category term="engineering"></category><category term="azure-devops"></category><category term="version-control"></category></entry><entry><title>Mastering the Art of Prompting: Pre-.NET10 Upgrade Analysis</title><link href="https://wsbctechnicalblog.github.io/ai-fundamentals-prompts-pre-dotnet-10-upgrade-analysis.html" rel="alternate"></link><published>2026-02-24T00:00:00-08:00</published><updated>2026-02-24T00:00:00-08:00</updated><author><name>Andreas Mertens</name></author><id>tag:wsbctechnicalblog.github.io,2026-02-24:/ai-fundamentals-prompts-pre-dotnet-10-upgrade-analysis.html</id><summary type="html">&lt;p&gt;How We Use GitHub Copilot to Validate Application Health Ahead of a .NET Upgrade&lt;/p&gt;</summary><content type="html">&lt;p&gt;Upgrading a core technology stack is never just a technical exercise. It is a stakeholder experience challenge, a risk management exercise, and a cost avoidance opportunity. Before committing to a .NET upgrade, we need a clear, evidence‑based view of the health of our applications and the effort required to move forward with confidence.&lt;/p&gt;
 &lt;p&gt;In this post, I will offer a practical peek into how we analyse application health using GitHub Copilot as an assistive capability, not a shortcut. We focus on understanding code quality, dependency risk, architectural debt, and upgrade readiness across our portfolio. GitHub Copilot helps us accelerate discovery, highlight patterns, and surface potential issues earlier, allowing our teams to spend more time on judgement, decision‑making, and remediation.&lt;/p&gt;
 &lt;blockquote&gt;
 &lt;p&gt;&lt;img alt="Analysis Image" src="../images/ai-fundamentals-prompts-pre-dotnet-10-upgrade-analysis-1.png"&gt; &lt;/p&gt;
@@ -3613,96 +3710,6 @@ These are my living &lt;strong&gt;personal&lt;/strong&gt; study notes. Use them 
 &lt;p&gt;Enjoy other learning notes:&lt;/p&gt;
 &lt;ul&gt;
 &lt;li&gt;&lt;a href="/ai-fundamentals-ai900-common-machine-learning-types.html"&gt;common-machine-learning-types&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href="/ai-fundamentals-ai900-common-workloads.html"&gt;common-workloads&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href="/ai-fundamentals-ai900-generative-ai.html"&gt;generative-ai&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href="/ai-fundamentals-ai900-ai-guiding-principles.html"&gt;guiding-principles&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href="/ai-fundamentals-ai900-natural-language-processing.html"&gt;natural-language-processing&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href="/ai-fundamentals-ai900-vision-workloads.html"&gt;vision-workloads&lt;/a&gt;&lt;/li&gt;
-&lt;/ul&gt;
-&lt;p&gt;AI-900 Quick reference Poster:&lt;/p&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;a href="/ai-fundamentals-ai900-poster.html"&gt;ai-900 poster&lt;/a&gt;&lt;/li&gt;
-&lt;/ul&gt;</content><category term="Posts"></category><category term="ai"></category><category term="learning"></category></entry><entry><title>Artificial Intelligence - AI-900 - Common Machine Learning Types</title><link href="https://wsbctechnicalblog.github.io/ai-fundamentals-ai900-common-machine-learning-types.html" rel="alternate"></link><published>2024-09-27T00:00:00-07:00</published><updated>2024-09-27T00:00:00-07:00</updated><author><name>Willy-Peter Schaub</name></author><id>tag:wsbctechnicalblog.github.io,2024-09-27:/ai-fundamentals-ai900-common-machine-learning-types.html</id><summary type="html">&lt;p&gt;"AI machine learning (ML) refers to the subset of artificial intelligence focused on developing algorithms and models that enable computers to learn from data and improve their performance over time without being explicitly programmed." - ChatGPT GPT-4o&lt;/p&gt;</summary><content type="html">&lt;blockquote&gt;
-&lt;p&gt;&lt;img alt="alert" src="../images/alert-tiny.png"&gt;
-These are my living &lt;strong&gt;personal&lt;/strong&gt; study notes. Use them at your own &lt;strong&gt;risk&lt;/strong&gt;!
-&lt;/p&gt;
-&lt;p&gt;&lt;img alt="common-machine-learning-types" src="../images/ai-fundamentals-ai900-common-machine-learning-types.png"&gt; &lt;/p&gt;
-&lt;/blockquote&gt;
-&lt;h2&gt;Notes&lt;/h2&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;strong&gt;Classification&lt;/strong&gt; predicts categories of data, such as sentiment if users on the X platform.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Clustering algorithm&lt;/strong&gt; automatically finds the optimal way to split a data set into groups without training.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Feature engineering&lt;/strong&gt; is the method of creating new features, based on existing features.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Feature selection&lt;/strong&gt; allows us to narrow down the features that are important for &lt;strong&gt;label&lt;/strong&gt; predictions.&lt;/li&gt;
-&lt;li&gt;Training a &lt;strong&gt;Regression&lt;/strong&gt; model involves data gathering and transformation: &lt;strong&gt;Feature selection&lt;/strong&gt; --&amp;gt; &lt;strong&gt;Finding and Cleaning&lt;/strong&gt; outliers --&amp;gt; &lt;strong&gt;Impute&lt;/strong&gt; missing values --&amp;gt; &lt;strong&gt;Normalization&lt;/strong&gt; or &lt;strong&gt;Feature engineering&lt;/strong&gt;.&lt;/li&gt;
-&lt;/ul&gt;
-&lt;h2&gt;Metrics&lt;/h2&gt;
-&lt;blockquote&gt;
-&lt;p&gt;Confusion Matrix Terms
-&lt;/p&gt;
-&lt;/blockquote&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;strong&gt;True Positive (TP)&lt;/strong&gt; - number of positive cases predicted correctly.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;True Negative (TN)&lt;/strong&gt; - number of negative cases predicted correctly.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;False Positive (FP)&lt;/strong&gt; - number of positive cases predicted incorrectly - Type 1 error.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;False Negative (FN)&lt;/strong&gt; - number of negative cases predicted incorrectly - Type 2 error.&lt;/li&gt;
-&lt;/ul&gt;
-&lt;blockquote&gt;
-&lt;p&gt;Classification model
-&lt;/p&gt;
-&lt;/blockquote&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;strong&gt;Accuracy&lt;/strong&gt; - the ratio of predictions that exactly match the true class labels. Closer to 1 the better. Range: [0, 1]. Metric = (TP+TN)/(TP+FP+TN+FN).&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Area Under Curve (AUC)&lt;/strong&gt; reflects the model's performance - AUC=&lt;strong&gt;1&lt;/strong&gt; is best fitted model and AUC&amp;lt;&lt;strong&gt;0.5&lt;/strong&gt; is worse than random. Range: [0, 1].&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;AveragePrecision (AP)&lt;/strong&gt; is the combined metrics of both Precision and Recall, used in vision model.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Confusion matrix&lt;/strong&gt; provides a tabulated view of predicted abd actual values.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;F1 Score&lt;/strong&gt; - machine learning evaluation metric that combines precision and recall scores. Metric = (2&lt;em&gt;Precision&lt;/em&gt;Recall)/(Precision+Recall).&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Precision&lt;/strong&gt; - the ability of a model to avoid labeling negative samples as positive. Closer to 1 the better. Range: [0, 1]. Metric = TP/(TP+FP).&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Recall&lt;/strong&gt; - the ability of a model to detect all positive samples. Closer to 1 the better. Range: [0, 1]. TP/(TP+FN), where TP=true positive, FN=False negative.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Selectivity&lt;/strong&gt; - measures the ability of the model to correctly identify negative samples (i.e., true negatives) out of all the actual negative samples. Metric = TN/(TN+FP).&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Specificity&lt;/strong&gt; - the ability of a model to correctly identify negative instances. TN/(TN+FP)&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Weighted accuracy&lt;/strong&gt; is accuracy where each sample is weighted by the total number of samples belonging to the same class. Closer to 1 the better. Range: [0, 1].&lt;/li&gt;
-&lt;/ul&gt;
-&lt;blockquote&gt;
-&lt;p&gt;Regression Model
-&lt;/p&gt;
-&lt;/blockquote&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;strong&gt;Coefficient of determination&lt;/strong&gt;, often referred to as R2, represents the predictive power of the model. Closer to 1 the better. Range: [0, 1].&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Mean absolute error (MAE)&lt;/strong&gt; measures how close the predictions are to the actual outcomes. A lower score is better.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Root mean squared error (RMSE)&lt;/strong&gt; creates a single value that summarizes the error in the model. By squaring the difference, the metric disregards the difference between over-prediction and under-prediction.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Relative absolute error (RAE)&lt;/strong&gt; is the relative absolute difference between expected and actual values. The mean difference is divided by the arithmetic mean.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Relative squared error (RSE)&lt;/strong&gt; similarly normalizes the total squared error of the predicted values by dividing by the total squared error of the actual values.&lt;/li&gt;
-&lt;/ul&gt;
-&lt;blockquote&gt;
-&lt;p&gt;Clustering Model
-&lt;/p&gt;
-&lt;/blockquote&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;strong&gt;Average Distance to Other Center&lt;/strong&gt; represent how close, on average, each point in the cluster is to the centroids of all other clusters.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Average Distance to Cluster Center&lt;/strong&gt; represent the closeness of all points in a cluster to the centroid of that cluster.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Combined Evaluation&lt;/strong&gt; score at the bottom of each section of results lists the averaged scores for the clusters created in that particular model.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Maximal Distance to Cluster Center&lt;/strong&gt; represent the max of the distances between each point and the centroid of that point's cluster. High = dispersed.&lt;/li&gt;
-&lt;li&gt;&lt;strong&gt;Number of Points&lt;/strong&gt; shows how many data points were assigned to each cluster, along with the total overall number of data points in any cluster.&lt;/li&gt;
-&lt;/ul&gt;
-&lt;h2&gt;Example&lt;/h2&gt;
-&lt;blockquote&gt;
-&lt;p&gt;You need to examine historical data to forecast price ranges for your product. Label = prediction = price range.
-&lt;/p&gt;
-&lt;/blockquote&gt;
-&lt;ul&gt;
-&lt;li&gt;The &lt;strong&gt;classification&lt;/strong&gt; model is &lt;code&gt;suitable&lt;/code&gt; for supervised learning to determine &lt;code&gt;is it&lt;/code&gt; a low, medium, high, or very high price.&lt;/li&gt;
-&lt;li&gt;The &lt;strong&gt;regression&lt;/strong&gt; model is &lt;code&gt;inappropriate&lt;/code&gt; because it forecasts numerical values rather than determining whether something belongs to the "is it" class.&lt;/li&gt;
-&lt;li&gt;The &lt;strong&gt;clustering&lt;/strong&gt; model is &lt;code&gt;inappropriate&lt;/code&gt; because it clusters unlabeled data into similar groups.&lt;/li&gt;
-&lt;/ul&gt;
-&lt;hr&gt;
-&lt;p&gt;You perused:&lt;/p&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;strong&gt;this-&amp;gt;&lt;/strong&gt;&lt;a href="/ai-fundamentals-ai900-common-machine-learning-types.html"&gt;common-machine-learning-types&lt;/a&gt; &lt;/li&gt;
-&lt;/ul&gt;
-&lt;p&gt;Enjoy other learning notes:&lt;/p&gt;
-&lt;ul&gt;
-&lt;li&gt;&lt;a href="/ai-fundamentals-ai900-bots.html"&gt;bots&lt;/a&gt;&lt;/li&gt;
 &lt;li&gt;&lt;a href="/ai-fundamentals-ai900-common-workloads.html"&gt;common-workloads&lt;/a&gt;&lt;/li&gt;
 &lt;li&gt;&lt;a href="/ai-fundamentals-ai900-generative-ai.html"&gt;generative-ai&lt;/a&gt;&lt;/li&gt;
 &lt;li&gt;&lt;a href="/ai-fundamentals-ai900-ai-guiding-principles.html"&gt;guiding-principles&lt;/a&gt;&lt;/li&gt;

--- a/first-international-tdd-conference.html
+++ b/first-international-tdd-conference.html
@@ -122,13 +122,14 @@ How to organize a tech conference?</p>
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -155,7 +156,6 @@ How to organize a tech conference?</p>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -187,7 +187,7 @@ How to organize a tech conference?</p>
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/flow-of-work.html
+++ b/flow-of-work.html
@@ -139,13 +139,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -172,7 +173,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -204,7 +204,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/github-copilot-for-business-faq.html
+++ b/github-copilot-for-business-faq.html
@@ -129,13 +129,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -162,7 +163,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -194,7 +194,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/github-copilot-for-business-setup.html
+++ b/github-copilot-for-business-setup.html
@@ -263,13 +263,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -296,7 +297,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -328,7 +328,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/governance-manifestos-guardrails.html
+++ b/governance-manifestos-guardrails.html
@@ -168,13 +168,14 @@ Review AD AAD Security Groups for a list of organizational, project, and team-le
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -201,7 +202,6 @@ Review AD AAD Security Groups for a list of organizational, project, and team-le
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -233,7 +233,7 @@ Review AD AAD Security Groups for a list of organizational, project, and team-le
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/guest-leader.html
+++ b/guest-leader.html
@@ -158,13 +158,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -191,7 +192,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -223,7 +223,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/hammer-is-not-always-the-right-tool-for-the-job.html
+++ b/hammer-is-not-always-the-right-tool-for-the-job.html
@@ -135,13 +135,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -168,7 +169,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -200,7 +200,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/hexagonal-architecture-exaple.html
+++ b/hexagonal-architecture-exaple.html
@@ -149,13 +149,14 @@ One way to avoid painting ourselves into a corner when building complex automate
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -182,7 +183,6 @@ One way to avoid painting ourselves into a corner when building complex automate
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -214,7 +214,7 @@ One way to avoid painting ourselves into a corner when building complex automate
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/how-does-it-feel-to-tdd.html
+++ b/how-does-it-feel-to-tdd.html
@@ -117,13 +117,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -150,7 +151,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -182,7 +182,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/how-to-minimize-queueing.html
+++ b/how-to-minimize-queueing.html
@@ -152,13 +152,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -185,7 +186,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -217,7 +217,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/hypothesis-driven-development.html
+++ b/hypothesis-driven-development.html
@@ -213,13 +213,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -246,7 +247,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -278,7 +278,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/improving-dora-metrics.html
+++ b/improving-dora-metrics.html
@@ -182,13 +182,14 @@ Each organization and each team must ask themselves some questions. These are ju
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -215,7 +216,6 @@ Each organization and each team must ask themselves some questions. These are ju
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -247,7 +247,7 @@ Each organization and each team must ask themselves some questions. These are ju
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/incremental-and-iterative-development.html
+++ b/incremental-and-iterative-development.html
@@ -156,13 +156,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -189,7 +190,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -221,7 +221,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/index.html
+++ b/index.html
@@ -45,6 +45,18 @@
 
             <!-- prima pagina -->
             <div class="main-article">
+                <div class="read-more">Wed 25 February 2026</div>
+ 
+                <h2><a href="https://wsbctechnicalblog.github.io/engineering-practices-branch-rename.html" rel=Bookmark title="Permalink to Renaming Git Branches in Azure DevOps: A Simple Task, Eight Easy Steps, and Mild Despair">Renaming Git Branches in Azure DevOps: A Simple Task, Eight Easy Steps, and Mild Despair</a></h2>
+                <p>
+                <p>How a One-Character Change Turned into a Full-Contact Git Exercise</p>            
+                </p>
+                   
+
+            </div>
+    
+            <!-- prima pagina -->
+            <div class="main-article">
                 <div class="read-more">Tue 24 February 2026</div>
  
                 <h2><a href="https://wsbctechnicalblog.github.io/ai-fundamentals-prompts-pre-dotnet-10-upgrade-analysis.html" rel=Bookmark title="Permalink to Mastering the Art of Prompting: Pre-.NET10 Upgrade Analysis">Mastering the Art of Prompting: Pre-.NET10 Upgrade Analysis</a></h2>
@@ -3105,13 +3117,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -3138,7 +3151,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -3170,7 +3182,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/innovation-podcast-is-agile-dead.html
+++ b/innovation-podcast-is-agile-dead.html
@@ -109,13 +109,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -142,7 +143,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -174,7 +174,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/innovation-podcast-wsbc-msft.html
+++ b/innovation-podcast-wsbc-msft.html
@@ -119,13 +119,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -152,7 +153,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -184,7 +184,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/lunch-learn-revisiting-feature-flags.html
+++ b/lunch-learn-revisiting-feature-flags.html
@@ -222,13 +222,14 @@ You need an understanding of feature flags, governance around usage, maintenance
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -255,7 +256,6 @@ You need an understanding of feature flags, governance around usage, maintenance
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -287,7 +287,7 @@ You need an understanding of feature flags, governance around usage, maintenance
                 <ul>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/make-yourself-interruptible.html
+++ b/make-yourself-interruptible.html
@@ -117,13 +117,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -150,7 +151,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -182,7 +182,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/meetup-devops-meetup-2024-03-26.html
+++ b/meetup-devops-meetup-2024-03-26.html
@@ -128,13 +128,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -161,7 +162,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -193,7 +193,7 @@
                 <ul>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/meetup-devops-meetup-2024-05-28.html
+++ b/meetup-devops-meetup-2024-05-28.html
@@ -111,13 +111,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -144,7 +145,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -176,7 +176,7 @@
                 <ul>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/meetup-devops-meetup-wsbc-pipeline-story.html
+++ b/meetup-devops-meetup-wsbc-pipeline-story.html
@@ -207,13 +207,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -240,7 +241,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -272,7 +272,7 @@
                 <ul>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/memory-lane-feature-flags.html
+++ b/memory-lane-feature-flags.html
@@ -165,13 +165,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -198,7 +199,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -230,7 +230,7 @@
                 <ul>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/metrics-importance.html
+++ b/metrics-importance.html
@@ -312,13 +312,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -345,7 +346,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -377,7 +377,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/mob-ownership.html
+++ b/mob-ownership.html
@@ -120,13 +120,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -153,7 +154,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -185,7 +185,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/moving-hundreds-of-pipeline-snowflakes-qr-1.html
+++ b/moving-hundreds-of-pipeline-snowflakes-qr-1.html
@@ -122,13 +122,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -155,7 +156,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -187,7 +187,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/moving-hundreds-of-pipeline-snowflakes-qr-2.html
+++ b/moving-hundreds-of-pipeline-snowflakes-qr-2.html
@@ -122,13 +122,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -155,7 +156,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -187,7 +187,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/moving-hundreds-of-pipeline-snowflakes-qr-3.html
+++ b/moving-hundreds-of-pipeline-snowflakes-qr-3.html
@@ -125,13 +125,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -158,7 +159,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -190,7 +190,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/only-changeable-design-is-good-design.html
+++ b/only-changeable-design-is-good-design.html
@@ -142,13 +142,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -175,7 +176,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -207,7 +207,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/ooda-loop-and-devops.html
+++ b/ooda-loop-and-devops.html
@@ -120,13 +120,14 @@ Ben's talk gave us a lot of food for thought and here I’d like to riff off som
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -153,7 +154,6 @@ Ben's talk gave us a lot of food for thought and here I’d like to riff off som
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -185,7 +185,7 @@ Ben's talk gave us a lot of food for thought and here I’d like to riff off som
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/ooda-one-of-the-devops-genomes.html
+++ b/ooda-one-of-the-devops-genomes.html
@@ -151,13 +151,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -184,7 +185,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -216,7 +216,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/optimize-and-avoid-emails.md.html
+++ b/optimize-and-avoid-emails.md.html
@@ -142,13 +142,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -175,7 +176,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -207,7 +207,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/optimize-and-track-emails.md.html
+++ b/optimize-and-track-emails.md.html
@@ -213,13 +213,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -246,7 +247,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -278,7 +278,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/our-open-source-pipeline-blueprints-have-landed.html
+++ b/our-open-source-pipeline-blueprints-have-landed.html
@@ -155,13 +155,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -188,7 +189,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -220,7 +220,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/pages/about.html
+++ b/pages/about.html
@@ -88,13 +88,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -121,7 +122,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -153,7 +153,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/pages/authors.html
+++ b/pages/authors.html
@@ -146,13 +146,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -179,7 +180,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -211,7 +211,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/pages/copyright.html
+++ b/pages/copyright.html
@@ -65,13 +65,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -98,7 +99,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -130,7 +130,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/pages/privacy.html
+++ b/pages/privacy.html
@@ -76,13 +76,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -109,7 +110,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -141,7 +141,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/pages/terms-of-use.html
+++ b/pages/terms-of-use.html
@@ -70,13 +70,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -103,7 +104,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -135,7 +135,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/peek-into-regular-expressions.html
+++ b/peek-into-regular-expressions.html
@@ -209,13 +209,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -242,7 +243,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -274,7 +274,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/pipelines-as-code-pr.html
+++ b/pipelines-as-code-pr.html
@@ -163,13 +163,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -196,7 +197,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -228,7 +228,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/pipelines-badges.html
+++ b/pipelines-badges.html
@@ -116,13 +116,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -149,7 +150,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -181,7 +181,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/pipelines-streamlined-approvals-new-world.html
+++ b/pipelines-streamlined-approvals-new-world.html
@@ -138,13 +138,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -171,7 +172,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -203,7 +203,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/pipelines-streamlined-approvals.html
+++ b/pipelines-streamlined-approvals.html
@@ -142,13 +142,14 @@ Artifact filters can be overridden if you have relevant permissions. If you need
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -175,7 +176,6 @@ Artifact filters can be overridden if you have relevant permissions. If you need
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -207,7 +207,7 @@ Artifact filters can be overridden if you have relevant permissions. If you need
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/plate-emptying.html
+++ b/plate-emptying.html
@@ -128,13 +128,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -161,7 +162,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -193,7 +193,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/popcorn-flow.html
+++ b/popcorn-flow.html
@@ -180,13 +180,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -213,7 +214,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -245,7 +245,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/pull-request-descriptions-empowered-by-engineering-practices.html
+++ b/pull-request-descriptions-empowered-by-engineering-practices.html
@@ -198,13 +198,14 @@ Honesty beats false completeness.</p>
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -231,7 +232,6 @@ Honesty beats false completeness.</p>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -263,7 +263,7 @@ Honesty beats false completeness.</p>
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/pull-request-empowered-by-engineering-practices.html
+++ b/pull-request-empowered-by-engineering-practices.html
@@ -223,13 +223,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -256,7 +257,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -288,7 +288,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/pull-requests-friend.html
+++ b/pull-requests-friend.html
@@ -167,13 +167,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -200,7 +201,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -232,7 +232,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/quality-assurance-automation-ai.html
+++ b/quality-assurance-automation-ai.html
@@ -144,13 +144,14 @@ Major areas benefiting significantly from automation include:</p>
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -177,7 +178,6 @@ Major areas benefiting significantly from automation include:</p>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -209,7 +209,7 @@ Major areas benefiting significantly from automation include:</p>
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/quality-of-design.html
+++ b/quality-of-design.html
@@ -149,13 +149,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -182,7 +183,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -214,7 +214,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/refactoring-saves-time-and-increases-quaity.html
+++ b/refactoring-saves-time-and-increases-quaity.html
@@ -121,13 +121,14 @@ Another bad smell on the rapidly advancing project is unused functionality. Seem
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -154,7 +155,6 @@ Another bad smell on the rapidly advancing project is unused functionality. Seem
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -186,7 +186,7 @@ Another bad smell on the rapidly advancing project is unused functionality. Seem
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/remove-redundant-tests.html
+++ b/remove-redundant-tests.html
@@ -209,13 +209,14 @@ Great news. Let’s carry on by removing the second test (<em>TerribleRatingIs0T
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -242,7 +243,6 @@ Great news. Let’s carry on by removing the second test (<em>TerribleRatingIs0T
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -274,7 +274,7 @@ Great news. Let’s carry on by removing the second test (<em>TerribleRatingIs0T
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/replace-roadmaps-with-seacharts.html
+++ b/replace-roadmaps-with-seacharts.html
@@ -125,13 +125,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -158,7 +159,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -190,7 +190,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/rotting-pull-requests.html
+++ b/rotting-pull-requests.html
@@ -148,13 +148,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -181,7 +182,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -213,7 +213,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/selling-technical-excellence.html
+++ b/selling-technical-excellence.html
@@ -130,13 +130,14 @@ Fast forward to today, and looking back, I can gather some of my observations an
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -163,7 +164,6 @@ Fast forward to today, and looking back, I can gather some of my observations an
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -195,7 +195,7 @@ Fast forward to today, and looking back, I can gather some of my observations an
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/servant-stewardship-of-guardrails.html
+++ b/servant-stewardship-of-guardrails.html
@@ -129,13 +129,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -162,7 +163,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -194,7 +194,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/share-your-toolbox-with-pipelines.html
+++ b/share-your-toolbox-with-pipelines.html
@@ -192,13 +192,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -225,7 +226,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -257,7 +257,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/shared-area-paths.html
+++ b/shared-area-paths.html
@@ -145,13 +145,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -178,7 +179,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -210,7 +210,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/sharing-variables-amongst-agents.html
+++ b/sharing-variables-amongst-agents.html
@@ -342,13 +342,14 @@ Why is the version not flowing, as expected?</p>
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -375,7 +376,6 @@ Why is the version not flowing, as expected?</p>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -407,7 +407,7 @@ Why is the version not flowing, as expected?</p>
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/sharing-variables-with-stages-and-jobs.html
+++ b/sharing-variables-with-stages-and-jobs.html
@@ -287,13 +287,14 @@ If you refer to your forearm and look at the tattoo for mapping a variable withi
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -320,7 +321,6 @@ If you refer to your forearm and look at the tattoo for mapping a variable withi
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -352,7 +352,7 @@ If you refer to your forearm and look at the tattoo for mapping a variable withi
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/shift-from-project-to-product-thinking.html
+++ b/shift-from-project-to-product-thinking.html
@@ -131,13 +131,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -164,7 +165,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -196,7 +196,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/shift-left-2am-call.html
+++ b/shift-left-2am-call.html
@@ -137,13 +137,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -170,7 +171,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -202,7 +202,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/software-engineering-standardization.html
+++ b/software-engineering-standardization.html
@@ -129,13 +129,14 @@ Each of these aspects are broad in nature, and when standardized can harmonized 
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -162,7 +163,6 @@ Each of these aspects are broad in nature, and when standardized can harmonized 
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -194,7 +194,7 @@ Each of these aspects are broad in nature, and when standardized can harmonized 
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/standardize-or-not-to-standardize.html
+++ b/standardize-or-not-to-standardize.html
@@ -169,13 +169,14 @@ I hope that the set of questions above can help with the decision. Good luck!</p
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -202,7 +203,6 @@ I hope that the set of questions above can help with the decision. Good luck!</p
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -234,7 +234,7 @@ I hope that the set of questions above can help with the decision. Good luck!</p
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/start-together-work-together-finish-together.html
+++ b/start-together-work-together-finish-together.html
@@ -137,13 +137,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -170,7 +171,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -202,7 +202,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/stop-the-confusing-language-madness-in-it.html
+++ b/stop-the-confusing-language-madness-in-it.html
@@ -192,13 +192,14 @@ WHAT + <strong>ASK</strong> + WHY = <strong>ACT</strong>IONABLE
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -225,7 +226,6 @@ WHAT + <strong>ASK</strong> + WHY = <strong>ACT</strong>IONABLE
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -257,7 +257,7 @@ WHAT + <strong>ASK</strong> + WHY = <strong>ACT</strong>IONABLE
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/stop-the-email-hell.html
+++ b/stop-the-email-hell.html
@@ -186,13 +186,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -219,7 +220,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -251,7 +251,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/stop-the-meeting-hell.html
+++ b/stop-the-meeting-hell.html
@@ -150,13 +150,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -183,7 +184,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -215,7 +215,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/suppress-pipeline-as-code-for-pr.html
+++ b/suppress-pipeline-as-code-for-pr.html
@@ -124,13 +124,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -157,7 +158,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -189,7 +189,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/synchronized-if-statements-considered-harmful.html
+++ b/synchronized-if-statements-considered-harmful.html
@@ -138,13 +138,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -171,7 +172,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -203,7 +203,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/systems-thinking.html
+++ b/systems-thinking.html
@@ -124,13 +124,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -157,7 +158,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -189,7 +189,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/101.html
+++ b/tag/101.html
@@ -140,13 +140,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -173,7 +174,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -205,7 +205,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/agile.html
+++ b/tag/agile.html
@@ -392,13 +392,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -425,7 +426,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -457,7 +457,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/ai.html
+++ b/tag/ai.html
@@ -284,13 +284,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -317,7 +318,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -349,7 +349,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/architecture.html
+++ b/tag/architecture.html
@@ -113,13 +113,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -146,7 +147,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -178,7 +178,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/automation.html
+++ b/tag/automation.html
@@ -302,13 +302,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -335,7 +336,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -367,7 +367,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/azure-devops.html
+++ b/tag/azure-devops.html
@@ -43,6 +43,15 @@
 
 <blocks cols="2">
         <div class="sec-article">
+            <div class="read-more">Wed 25 February 2026</div>
+
+            <h3><a href="https://wsbctechnicalblog.github.io/engineering-practices-branch-rename.html" rel=Bookmark title="Permalink to Renaming Git Branches in Azure DevOps: A Simple Task, Eight Easy Steps, and Mild Despair">Renaming Git Branches in Azure DevOps: A Simple Task, Eight Easy Steps, and Mild Despair</a></h3>
+            <p>
+            <p>How a One-Character Change Turned into a Full-Contact Git Exercise</p>            
+            </p>
+        </div>
+
+        <div class="sec-article">
             <div class="read-more">Mon 26 January 2026</div>
 
             <h3><a href="https://wsbctechnicalblog.github.io/zero-or-one-not-fault-lines-is-azure-devops-doomed.html" rel=Bookmark title="Permalink to Zero or One, not Fault Lines - Is Azure DevOps Doomed?">Zero or One, not Fault Lines - Is Azure DevOps Doomed?</a></h3>
@@ -950,13 +959,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -983,7 +993,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -1015,7 +1024,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/azure.html
+++ b/tag/azure.html
@@ -95,13 +95,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -128,7 +129,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -160,7 +160,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/book.html
+++ b/tag/book.html
@@ -77,13 +77,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -110,7 +111,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -142,7 +142,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/books.html
+++ b/tag/books.html
@@ -77,13 +77,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -110,7 +111,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -142,7 +142,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/ceremony.html
+++ b/tag/ceremony.html
@@ -140,13 +140,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -173,7 +174,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -205,7 +205,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/code-quality.html
+++ b/tag/code-quality.html
@@ -212,13 +212,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -245,7 +246,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -277,7 +277,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/code.html
+++ b/tag/code.html
@@ -311,13 +311,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -344,7 +345,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -376,7 +376,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/collaboration.html
+++ b/tag/collaboration.html
@@ -86,13 +86,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -119,7 +120,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -151,7 +151,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/continuous-delivery.html
+++ b/tag/continuous-delivery.html
@@ -86,13 +86,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -119,7 +120,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -151,7 +151,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/coop.html
+++ b/tag/coop.html
@@ -86,13 +86,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -119,7 +120,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -151,7 +151,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/customer-centric.html
+++ b/tag/customer-centric.html
@@ -77,13 +77,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -110,7 +111,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -142,7 +142,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/delivery-on-demand.html
+++ b/tag/delivery-on-demand.html
@@ -86,13 +86,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -119,7 +120,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -151,7 +151,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/design.html
+++ b/tag/design.html
@@ -86,13 +86,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -119,7 +120,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -151,7 +151,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/devops.html
+++ b/tag/devops.html
@@ -563,13 +563,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -596,7 +597,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -628,7 +628,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/dojo.html
+++ b/tag/dojo.html
@@ -77,13 +77,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -110,7 +111,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -142,7 +142,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/eliminate-waste.html
+++ b/tag/eliminate-waste.html
@@ -284,13 +284,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -317,7 +318,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -349,7 +349,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/engineering.html
+++ b/tag/engineering.html
@@ -43,6 +43,15 @@
 
 <blocks cols="2">
         <div class="sec-article">
+            <div class="read-more">Wed 25 February 2026</div>
+
+            <h3><a href="https://wsbctechnicalblog.github.io/engineering-practices-branch-rename.html" rel=Bookmark title="Permalink to Renaming Git Branches in Azure DevOps: A Simple Task, Eight Easy Steps, and Mild Despair">Renaming Git Branches in Azure DevOps: A Simple Task, Eight Easy Steps, and Mild Despair</a></h3>
+            <p>
+            <p>How a One-Character Change Turned into a Full-Contact Git Exercise</p>            
+            </p>
+        </div>
+
+        <div class="sec-article">
             <div class="read-more">Mon 16 February 2026</div>
 
             <h3><a href="https://wsbctechnicalblog.github.io/zero-or-one-not-fault-lines-asking-the-right-ai-question.html" rel=Bookmark title="Permalink to Zero or One, not Fault Lines - Are we asking the right AI question?">Zero or One, not Fault Lines - Are we asking the right AI question?</a></h3>
@@ -752,13 +761,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -785,7 +795,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -817,7 +826,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/estimates.html
+++ b/tag/estimates.html
@@ -86,13 +86,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -119,7 +120,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -151,7 +151,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/event.html
+++ b/tag/event.html
@@ -158,13 +158,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -191,7 +192,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -223,7 +223,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/events.html
+++ b/tag/events.html
@@ -95,13 +95,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -128,7 +129,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -160,7 +160,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/feature-flags.html
+++ b/tag/feature-flags.html
@@ -104,13 +104,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -137,7 +138,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -169,7 +169,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/flow.html
+++ b/tag/flow.html
@@ -77,13 +77,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -110,7 +111,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -142,7 +142,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/github.html
+++ b/tag/github.html
@@ -86,13 +86,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -119,7 +120,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -151,7 +151,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/innovation.html
+++ b/tag/innovation.html
@@ -131,13 +131,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -164,7 +165,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -196,7 +196,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/journal.html
+++ b/tag/journal.html
@@ -185,13 +185,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -218,7 +219,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -250,7 +250,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/lean.html
+++ b/tag/lean.html
@@ -95,13 +95,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -128,7 +129,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -160,7 +160,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/learning.html
+++ b/tag/learning.html
@@ -563,13 +563,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -596,7 +597,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -628,7 +628,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/metrics.html
+++ b/tag/metrics.html
@@ -95,13 +95,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -128,7 +129,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -160,7 +160,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/no-estimates.html
+++ b/tag/no-estimates.html
@@ -77,13 +77,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -110,7 +111,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -142,7 +142,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/oss.html
+++ b/tag/oss.html
@@ -122,13 +122,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -155,7 +156,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -187,7 +187,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/pipelines.html
+++ b/tag/pipelines.html
@@ -662,13 +662,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -695,7 +696,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -727,7 +727,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/planning.html
+++ b/tag/planning.html
@@ -77,13 +77,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -110,7 +111,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -142,7 +142,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/posters.html
+++ b/tag/posters.html
@@ -167,13 +167,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -200,7 +201,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -232,7 +232,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/process.html
+++ b/tag/process.html
@@ -86,13 +86,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -119,7 +120,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -151,7 +151,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/psychological-safety.html
+++ b/tag/psychological-safety.html
@@ -77,13 +77,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -110,7 +111,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -142,7 +142,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/quality.html
+++ b/tag/quality.html
@@ -239,13 +239,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -272,7 +273,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -304,7 +304,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/release.html
+++ b/tag/release.html
@@ -77,13 +77,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -110,7 +111,6 @@
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -142,7 +142,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/security.html
+++ b/tag/security.html
@@ -77,13 +77,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -110,7 +111,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -142,7 +142,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/standards.html
+++ b/tag/standards.html
@@ -77,13 +77,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -110,7 +111,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -142,7 +142,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/strategy.html
+++ b/tag/strategy.html
@@ -77,13 +77,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -110,7 +111,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -142,7 +142,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/system-programming.html
+++ b/tag/system-programming.html
@@ -77,13 +77,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -110,7 +111,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -142,7 +142,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/tdd.html
+++ b/tag/tdd.html
@@ -176,13 +176,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -209,7 +210,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -241,7 +241,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/team-building.html
+++ b/tag/team-building.html
@@ -77,13 +77,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -110,7 +111,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -142,7 +142,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/technical-excellence.html
+++ b/tag/technical-excellence.html
@@ -257,13 +257,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -290,7 +291,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -322,7 +322,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/testability.html
+++ b/tag/testability.html
@@ -77,13 +77,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -110,7 +111,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -142,7 +142,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/testing.html
+++ b/tag/testing.html
@@ -203,13 +203,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -236,7 +237,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -268,7 +268,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/tips.html
+++ b/tag/tips.html
@@ -338,13 +338,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -371,7 +372,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -403,7 +403,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/value.html
+++ b/tag/value.html
@@ -86,13 +86,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -119,7 +120,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -151,7 +151,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/version-control.html
+++ b/tag/version-control.html
@@ -43,6 +43,15 @@
 
 <blocks cols="2">
         <div class="sec-article">
+            <div class="read-more">Wed 25 February 2026</div>
+
+            <h3><a href="https://wsbctechnicalblog.github.io/engineering-practices-branch-rename.html" rel=Bookmark title="Permalink to Renaming Git Branches in Azure DevOps: A Simple Task, Eight Easy Steps, and Mild Despair">Renaming Git Branches in Azure DevOps: A Simple Task, Eight Easy Steps, and Mild Despair</a></h3>
+            <p>
+            <p>How a One-Character Change Turned into a Full-Contact Git Exercise</p>            
+            </p>
+        </div>
+
+        <div class="sec-article">
             <div class="read-more">Fri 02 September 2022</div>
 
             <h3><a href="https://wsbctechnicalblog.github.io/branching-trunk-based.html" rel=Bookmark title="Permalink to Trunk-based branching strategy without the bells and whistles">Trunk-based branching strategy without the bells and whistles</a></h3>
@@ -104,13 +113,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -137,7 +147,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -169,7 +178,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/water-cooler.html
+++ b/tag/water-cooler.html
@@ -86,13 +86,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -119,7 +120,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -151,7 +151,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/workflow.html
+++ b/tag/workflow.html
@@ -77,13 +77,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -110,7 +111,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -142,7 +142,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/x-as-code.html
+++ b/tag/x-as-code.html
@@ -212,13 +212,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -245,7 +246,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -277,7 +277,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tag/xp.html
+++ b/tag/xp.html
@@ -113,13 +113,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -146,7 +147,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -178,7 +178,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/tags.html
+++ b/tags.html
@@ -44,7 +44,7 @@
         <li><a href="https://wsbctechnicalblog.github.io/tag/architecture.html">architecture</a> (5)</li>
         <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a> (26)</li>
         <li><a href="https://wsbctechnicalblog.github.io/tag/azure.html">azure</a> (3)</li>
-        <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a> (98)</li>
+        <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a> (99)</li>
         <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a> (1)</li>
         <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a> (1)</li>
         <li><a href="https://wsbctechnicalblog.github.io/tag/ceremony.html">ceremony</a> (8)</li>
@@ -59,7 +59,7 @@
         <li><a href="https://wsbctechnicalblog.github.io/tag/devops.html">devops</a> (55)</li>
         <li><a href="https://wsbctechnicalblog.github.io/tag/dojo.html">dojo</a> (1)</li>
         <li><a href="https://wsbctechnicalblog.github.io/tag/eliminate-waste.html">eliminate-waste</a> (24)</li>
-        <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a> (76)</li>
+        <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a> (77)</li>
         <li><a href="https://wsbctechnicalblog.github.io/tag/estimates.html">estimates</a> (2)</li>
         <li><a href="https://wsbctechnicalblog.github.io/tag/event.html">event</a> (10)</li>
         <li><a href="https://wsbctechnicalblog.github.io/tag/events.html">events</a> (3)</li>
@@ -91,7 +91,7 @@
         <li><a href="https://wsbctechnicalblog.github.io/tag/testing.html">testing</a> (15)</li>
         <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a> (30)</li>
         <li><a href="https://wsbctechnicalblog.github.io/tag/value.html">value</a> (2)</li>
-        <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a> (4)</li>
+        <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a> (5)</li>
         <li><a href="https://wsbctechnicalblog.github.io/tag/water-cooler.html">water-cooler</a> (2)</li>
         <li><a href="https://wsbctechnicalblog.github.io/tag/workflow.html">workflow</a> (1)</li>
         <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a> (16)</li>

--- a/tdd-for-nontechies.html
+++ b/tdd-for-nontechies.html
@@ -146,13 +146,14 @@ The test-driven approach requires automatic verifications that confirm whether o
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -179,7 +180,6 @@ The test-driven approach requires automatic verifications that confirm whether o
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -211,7 +211,7 @@ The test-driven approach requires automatic verifications that confirm whether o
                 <ul>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/technical-event-speakers.html
+++ b/technical-event-speakers.html
@@ -165,13 +165,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -198,7 +199,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -230,7 +230,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/technology-adoption-program.html
+++ b/technology-adoption-program.html
@@ -153,13 +153,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -186,7 +187,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -218,7 +218,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/test-environment-management-in-a-hybrid-world.html
+++ b/test-environment-management-in-a-hybrid-world.html
@@ -117,13 +117,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -150,7 +151,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -182,7 +182,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/the-cost-of-avoiding-change.html
+++ b/the-cost-of-avoiding-change.html
@@ -133,13 +133,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -166,7 +167,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -198,7 +198,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/the-move-to-team-project-feature.html
+++ b/the-move-to-team-project-feature.html
@@ -181,13 +181,14 @@ PowerShell Script to the Rescue</p>
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -214,7 +215,6 @@ PowerShell Script to the Rescue</p>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -246,7 +246,7 @@ PowerShell Script to the Rescue</p>
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/the-problem-with-big-batches.html
+++ b/the-problem-with-big-batches.html
@@ -148,13 +148,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -181,7 +182,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -213,7 +213,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/townhall.html
+++ b/townhall.html
@@ -150,13 +150,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -183,7 +184,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -215,7 +215,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/water-cooler-talk-why-azure-devops-is-not-a-silver-bullet.html
+++ b/water-cooler-talk-why-azure-devops-is-not-a-silver-bullet.html
@@ -115,13 +115,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -148,7 +149,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -180,7 +180,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/water-cooler-talk-why-is-wsbc-such-a-cool-place.html
+++ b/water-cooler-talk-why-is-wsbc-such-a-cool-place.html
@@ -122,13 +122,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -155,7 +156,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -187,7 +187,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/what-about-chatgpt.html
+++ b/what-about-chatgpt.html
@@ -141,13 +141,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -174,7 +175,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -206,7 +206,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/what-is-value.html
+++ b/what-is-value.html
@@ -150,13 +150,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -183,7 +184,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -215,7 +215,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/what-keeps-us-awake-at-night-patching.html
+++ b/what-keeps-us-awake-at-night-patching.html
@@ -192,13 +192,14 @@ Sustainment, maintenance, and housekeeping is something that should be part of e
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -225,7 +226,6 @@ Sustainment, maintenance, and housekeeping is something that should be part of e
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -257,7 +257,7 @@ Sustainment, maintenance, and housekeeping is something that should be part of e
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/when-should-we-automate-tests.html
+++ b/when-should-we-automate-tests.html
@@ -128,13 +128,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -161,7 +162,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -193,7 +193,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/why-bother-with-governance.html
+++ b/why-bother-with-governance.html
@@ -153,13 +153,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -186,7 +187,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -218,7 +218,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/why-extract-methods.html
+++ b/why-extract-methods.html
@@ -143,13 +143,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -176,7 +177,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -208,7 +208,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/why-i-hate-tlas.html
+++ b/why-i-hate-tlas.html
@@ -135,13 +135,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -168,7 +169,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -200,7 +200,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/why-pipelines-part1.html
+++ b/why-pipelines-part1.html
@@ -188,13 +188,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -221,7 +222,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -253,7 +253,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/why-release-on-demand.html
+++ b/why-release-on-demand.html
@@ -146,13 +146,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -179,7 +180,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -211,7 +211,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/why-we-care-about-iac.html
+++ b/why-we-care-about-iac.html
@@ -133,13 +133,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -166,7 +167,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -198,7 +198,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/wired-4-change-journal.html
+++ b/wired-4-change-journal.html
@@ -135,13 +135,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -168,7 +169,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -200,7 +200,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/work-about-work.html
+++ b/work-about-work.html
@@ -120,13 +120,14 @@ However, the moment we start gunning for the work-in-parallel, we are creating b
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -153,7 +154,6 @@ However, the moment we start gunning for the work-in-parallel, we are creating b
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -185,7 +185,7 @@ However, the moment we start gunning for the work-in-parallel, we are creating b
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/workflow-as-code.html
+++ b/workflow-as-code.html
@@ -125,13 +125,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -158,7 +159,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -190,7 +190,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/wsbc-devops-celebrate-hundredth-sprint.html
+++ b/wsbc-devops-celebrate-hundredth-sprint.html
@@ -120,13 +120,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -153,7 +154,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -185,7 +185,7 @@
                 <ul>
                     <li class="active"><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/xp-25-years-later.html
+++ b/xp-25-years-later.html
@@ -147,13 +147,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -180,7 +181,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -212,7 +212,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/xp-options.html
+++ b/xp-options.html
@@ -134,13 +134,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -167,7 +168,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -199,7 +199,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/yaml-pipelines-part10.html
+++ b/yaml-pipelines-part10.html
@@ -235,13 +235,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -268,7 +269,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -300,7 +300,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/yaml-pipelines-part11.html
+++ b/yaml-pipelines-part11.html
@@ -148,13 +148,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -181,7 +182,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -213,7 +213,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/yaml-pipelines-part2.html
+++ b/yaml-pipelines-part2.html
@@ -338,13 +338,14 @@ steps:
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -371,7 +372,6 @@ steps:
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -403,7 +403,7 @@ steps:
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/yaml-pipelines-part3.html
+++ b/yaml-pipelines-part3.html
@@ -241,13 +241,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -274,7 +275,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -306,7 +306,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/yaml-pipelines-part4.html
+++ b/yaml-pipelines-part4.html
@@ -202,13 +202,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -235,7 +236,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -267,7 +267,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/yaml-pipelines-part5.html
+++ b/yaml-pipelines-part5.html
@@ -344,13 +344,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -377,7 +378,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -409,7 +409,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/yaml-pipelines-part6.html
+++ b/yaml-pipelines-part6.html
@@ -249,13 +249,14 @@ Our Bootstrap.yml templates is a standard YAML-template, as are the templates it
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -282,7 +283,6 @@ Our Bootstrap.yml templates is a standard YAML-template, as are the templates it
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -314,7 +314,7 @@ Our Bootstrap.yml templates is a standard YAML-template, as are the templates it
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/yaml-pipelines-part7.html
+++ b/yaml-pipelines-part7.html
@@ -218,13 +218,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -251,7 +252,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -283,7 +283,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/yaml-pipelines-part8.html
+++ b/yaml-pipelines-part8.html
@@ -335,13 +335,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -368,7 +369,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -400,7 +400,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/yaml-pipelines-part9.html
+++ b/yaml-pipelines-part9.html
@@ -439,13 +439,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -472,7 +473,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -504,7 +504,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/zero-or-one-not-fault-lines-asking-the-right-ai-question.html
+++ b/zero-or-one-not-fault-lines-asking-the-right-ai-question.html
@@ -190,13 +190,14 @@ AI amplifies everything — including our weak points. If our processes are brok
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -223,7 +224,6 @@ AI amplifies everything — including our weak points. If our processes are brok
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -255,7 +255,7 @@ AI amplifies everything — including our weak points. If our processes are brok
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/zero-or-one-not-fault-lines-introduction-to-the-journal.html
+++ b/zero-or-one-not-fault-lines-introduction-to-the-journal.html
@@ -116,13 +116,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -149,7 +150,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -181,7 +181,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/zero-or-one-not-fault-lines-is-azure-devops-doomed.html
+++ b/zero-or-one-not-fault-lines-is-azure-devops-doomed.html
@@ -162,13 +162,14 @@ This is why our approach must remain deliberate, value‑driven, and grounded in
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -195,7 +196,6 @@ This is why our approach must remain deliberate, value‑driven, and grounded in
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -227,7 +227,7 @@ This is why our approach must remain deliberate, value‑driven, and grounded in
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>

--- a/zero-or-one-not-fault-lines-processes-slow-us-down.html
+++ b/zero-or-one-not-fault-lines-processes-slow-us-down.html
@@ -133,13 +133,14 @@
            <div class="large-6 tag-cloud column">
                 <h3>Tags</h3>
                 <ul>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(77)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(99)</li>
+                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(5)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/ai.html">ai</a>(24)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/learning.html">learning</a>(55)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/engineering.html">engineering</a>(76)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/journal.html">journal</a>(13)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/books.html">books</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/automation.html">automation</a>(26)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/azure-devops.html">azure-devops</a>(98)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/coop.html">coop</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/tips.html">tips</a>(30)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/code-quality.html">code-quality</a>(16)</li>
@@ -166,7 +167,6 @@
                     <li><a href="https://wsbctechnicalblog.github.io/tag/release.html">release</a>(1)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/x-as-code.html">x-as-code</a>(16)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/book.html">book</a>(1)</li>
-                    <li><a href="https://wsbctechnicalblog.github.io/tag/version-control.html">version-control</a>(4)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/metrics.html">metrics</a>(3)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/continuous-delivery.html">continuous-delivery</a>(2)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/tag/delivery-on-demand.html">delivery-on-demand</a>(2)</li>
@@ -198,7 +198,7 @@
                 <ul>
                     <li><a href="https://wsbctechnicalblog.github.io/category/events.html">Events</a> (10)</li>
                     <li><a href="https://wsbctechnicalblog.github.io/category/misc.html">misc</a> (2)</li>
-                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (241)</li>
+                    <li class="active"><a href="https://wsbctechnicalblog.github.io/category/posts.html">Posts</a> (242)</li>
                 </ul>
              
             </div>


### PR DESCRIPTION
- Added new tags for engineering, azure-devops, and version-control with updated counts.
- Removed outdated counts for engineering, azure-devops, and version-control tags.
- Incremented post count from 241 to 242 in various files.